### PR TITLE
Fix Version Number

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'


### PR DESCRIPTION
## DESC
Version 3.3.0 has already been released on PyPi but it was never updated here in that PR and hence there was inconsistency in the version number leading to wrong version bump in the successive PRs. This PR fixes the issue with the version number