### PR TITLE
fix: Fix LTI 1.1 template rendering on LTI 1.1 embeds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -367,6 +367,11 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+3.4.3 - 2022-02-01
+------------------
+
+* Fix LTI 1.1 template rendering when using embeds in the platform
+
 3.4.2 - 2022-02-01
 ------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.4.2'
+__version__ = '3.4.3'

--- a/lti_consumer/lti_1p1/contrib/django.py
+++ b/lti_consumer/lti_1p1/contrib/django.py
@@ -125,5 +125,5 @@ def lti_embed(
 
     # Render the form template and return the template
     loader = ResourceLoader(__name__)
-    template = loader.render_mako_template('../../templates/html/lti_launch.html', context)
+    template = loader.render_django_template('../../templates/html/lti_launch.html', context)
     return template

--- a/lti_consumer/lti_1p1/contrib/tests/test_django.py
+++ b/lti_consumer/lti_1p1/contrib/tests/test_django.py
@@ -105,10 +105,10 @@ class TestLtiEmbed(TestCase):
         mock_set_custom_parameters.assert_called_with(expected_custom_parameters)
 
     @patch('lti_consumer.lti_1p1.contrib.django.LtiConsumer1p1.generate_launch_request', Mock(return_value={'a': 1}))
-    @patch('lti_consumer.lti_1p1.contrib.django.ResourceLoader.render_mako_template')
-    def test_make_template_rendered_with_correct_context_and_returned(self, mock_render_mako_template):
+    @patch('lti_consumer.lti_1p1.contrib.django.ResourceLoader.render_django_template')
+    def test_make_template_rendered_with_correct_context_and_returned(self, mock_render_django_template):
         fake_template = 'SOME_TEMPLATE'
-        mock_render_mako_template.return_value = fake_template
+        mock_render_django_template.return_value = fake_template
 
         rendered_template = lti_embed(
             html_element_id=self.html_element_id,
@@ -132,5 +132,5 @@ class TestLtiEmbed(TestCase):
             'launch_url': self.lti_launch_url,
             'lti_parameters': {'a': 1}
         }
-        mock_render_mako_template.assert_called_with(ANY, expected_context)
+        mock_render_django_template.assert_called_with(ANY, expected_context)
         self.assertEqual(rendered_template, fake_template)


### PR DESCRIPTION
This fixes template rendering for LTI 1.1 embeds.

**Reviewers:**
- [x] @schenedx 
- [ ] @mraarif 