### PR TITLE
fix: LTI Deep linking launch parameter for H5P WIP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -367,6 +367,13 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+3.4.4 - 2022-03-03
+------------------
+
+* Fix LTI 1.3 Deep Linking launch url - always perform launch on launch URL, but update `target_link_uri` when
+  loading deep linking content.
+  See LTI 1.3 spec at: https://www.imsglobal.org/spec/lti/v1p3#target-link-uri
+
 3.4.3 - 2022-02-01
 ------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.4.3'
+__version__ = '3.4.4'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1145,8 +1145,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                     url=dl_params.get('url'),
                     custom=dl_params.get('custom')
                 )
-                if dl_params.get('url'):
-                    context.update({'launch_url': dl_params.get('url')})
 
             # Update context with LTI launch parameters
             context.update({

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1416,7 +1416,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertIn("https://deep-link-content/", content)
+        self.assertIn("http://tool.example/launch", content)
 
 
 class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):


### PR DESCRIPTION
This PR fixes content being launched after deep linking with H5P.

**Testing instructions:**
1. Set up a H5P integration using LTI 1.3
2. Set up Deep Linking.
3. Run a deep linking request (if you run into permission issues, comment out [this line](https://github.com/openedx/xblock-lti-consumer/blob/master/lti_consumer/plugin/views.py#L195) if testing locally).
4. Go to the LMS and check that H5P content is successfully launched.

**Validation testing:**
@schenedx Can you run the LTI validation tool with these recent changes? It needs to run the entire conformance suite so we know this isn't out of the spec.

**Notes:**
- This doesn't fix the LTI Deep Linking flow permission issues raised in this thread: https://openedx.slack.com/archives/C0GR05YC9/p1644575271361139

**Reviewer:**
- [ ] @schenedx 