### PR TITLE
237 lti 1p3 launch permission templates not rendered

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,11 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+3.4.6 - 2022-03-31
+------------------
+
+* Fix rendering of `lti_1p3_launch_error.html` and `lti_1p3_permission_error.html` templates
+
 3.4.5 - 2022-03-16
 ------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.4.5'
+__version__ = '3.4.6'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1163,7 +1163,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 str(self.location),  # pylint: disable=no-member
                 exc,
             )
-            template = loader.render_mako_template('/templates/html/lti_1p3_launch_error.html', context)
+            template = loader.render_django_template('/templates/html/lti_1p3_launch_error.html', context)
             return Response(template, status=400, content_type='text/html')
         except AssertionError as exc:
             log.warning(
@@ -1172,7 +1172,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 self.external_user_id,
                 exc,
             )
-            template = loader.render_mako_template('/templates/html/lti_1p3_permission_error.html', context)
+            template = loader.render_django_template('/templates/html/lti_1p3_permission_error.html', context)
             return Response(template, status=403, content_type='text/html')
 
     @XBlock.handler

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1268,6 +1268,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         response_body = response.body.decode('utf-8')
         self.assertIn("There was an error while launching the LTI 1.3 tool.", response_body)
+        self.assertNotIn("% trans", response_body)
 
     def test_launch_callback_endpoint_when_using_lti_1p1(self):
         """
@@ -1372,6 +1373,9 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         # Check response
         self.assertEqual(response.status_code, 403)
+        response_body = response.body.decode('utf-8')
+        self.assertIn("Students don't have permissions to perform", response_body)
+        self.assertNotIn("% trans", response_body)
 
     @patch('lti_consumer.api.get_deep_linking_data')
     def test_callback_endpoint_dl_content_launch(self, mock_dl_data):


### PR DESCRIPTION
Fixes #237 

- Changes `render_mako_template` -> `render_django_template` in `lti_1p3_launch_callback` exception handlers
- Check that `% trans` is not in response bodies so we know template was properly rendered