### PR TITLE
FAL-2844: Fix LTI Deep Linking permissions issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,9 +139,11 @@ Instructions:
 
 .. admonition:: Testing using ``ngrok``
 
-    When launching LTI 1.3 requests through ``ngrok``, make sure you set ``DCS_SESSION_COOKIE_SAMESITE = 'None'`` in your
-    ``devstack.py`` (located in /edx/app/edxapp/edx-platform/(lms|cms)/envs``) when doing LTI 1.3 launches in the
-    devstack through ngrok. Do not forget to restart your services after updating the ``.py`` files.
+    When launching LTI 1.3 requests through ``ngrok``, make sure your LMS is serving session cookies marked as
+    ``Secure`` and with the ``SameSite`` attribute set to ``None``. You can do this by changing ``SESSION_COOKIE_SECURE: true``
+    and ``DCS_SESSION_COOKIE_SAMESITE: None`` in your ``lms.yml`` configuration files. Note that this will break logins
+    for locally accessed URLs in the devstack.
+
 
 Custom LTI Parameters
 =====================
@@ -366,6 +368,12 @@ Changelog
 =========
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
+
+3.4.5 - 2022-03-16
+------------------
+
+* Fix LTI Deep Linking return endpoint permission checking method by replacing the old one with the proper
+  Studio API call.
 
 3.4.4 - 2022-03-03
 ------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '3.4.4'
+__version__ = '3.4.5'

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -113,6 +113,18 @@ def user_has_access(*args, **kwargs):
     return has_access(*args, **kwargs)
 
 
+def user_has_studio_write_access(*args, **kwargs):
+    """
+    Import and run `has_studio_write_access` from common modules.
+
+    Used to check if someone saving deep linking content has the
+    correct write permissions for a given.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from common.djangoapps.student.auth import has_studio_write_access
+    return has_studio_write_access(*args, **kwargs)
+
+
 def get_course_by_id(course_key):
     """
     Import and run `get_course_by_id` from LMS

--- a/lti_consumer/tests/unit/plugin/test_views_lti_deep_linking.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_deep_linking.py
@@ -89,10 +89,17 @@ class LtiDeepLinkingResponseEndpointTestCase(LtiDeepLinkingTestCase):
         super().setUp()
 
         # Patch method that calls platform core to ask for user permissions
-        studio_access_patcher = patch('lti_consumer.plugin.views.user_has_staff_access')
-        self.addCleanup(studio_access_patcher.stop)
-        self._mock_has_studio_write_acess = studio_access_patcher.start()
-        self._mock_has_studio_write_acess.return_value = True
+        compat_mock = patch("lti_consumer.signals.compat")
+        self.addCleanup(compat_mock.stop)
+        self._compat_mock = compat_mock.start()
+        self._compat_mock.user_has_studio_write_access.return_value = True
+
+        has_studio_write_acess_patcher = patch(
+            'lti_consumer.plugin.views.compat.user_has_studio_write_access',
+            return_value=True
+        )
+        self.addCleanup(has_studio_write_acess_patcher.stop)
+        self._mock_has_studio_write_acess = has_studio_write_acess_patcher.start()
 
         # Deep Linking response endpoint
         self.url = '/lti_consumer/v1/lti/{}/lti-dl/response'.format(self.lti_config.id)


### PR DESCRIPTION
This PR fixes a permissions check issue when saving Deep Linking content edits back into Studio. This was caused by the incorrect API being used causing it to error out when any user other than a superuser was used.

We're basically replacing the old check with a new call to Studio's `has_studio_write_access` with the right parameters.

**Testing instructions:**
_Testing instructions written to members with access to H5P testing tools._

Before following these instructions, make sure you have a publicly accessible devstack set up (instructions [here](https://github.com/openedx/xblock-lti-consumer#lti-13) - ignore the LTI tool setup steps).

1. Set up a LTI 1.3 integration on H5P (from H5P dashboard: `Manage organization` -> `Connect LMS`).
2. Add a new LTI consumer block in your devstack and configure it to use the H5P tool. Leave this tab open.
3. Change `lms.yml` variables to enable secure cookies with `SameSite=None` and restart the LMS:
```
LMS_ROOT_URL: yourtunnelurl.domain.com
SESSION_COOKIE_SECURE: true
DCS_SESSION_COOKIE_SAMESITE: None
```
_After this step, only logins from your secure `https` URL will work._
4. Go back to the studio tab and click on the `Deep Linking Launch - Configure tool` link.
5. Author a new problem and click `Save and insert` in H5P.
6. Wait for the LMS message mentioning that the content was saved.
7. Refresh the Studio page and check that the content you selected in H5P is listed there.
![image](https://user-images.githubusercontent.com/27893385/158664592-b552432b-afc4-48a4-88b3-cd48b7a681a7.png)
8. Launch the content from the LMS.

**Validation testing (edX only):**
Not required, but useful to confirm the changes are working as expected. 

**Reviewers:**
- [ ] @Agrendalath 
- [ ] @schenedx 