### PR TITLE
FC-0001: use modern waffle flag syntax

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.0.1'
+__version__ = '4.1.0'

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -38,7 +38,7 @@ def get_external_config_waffle_flag():
     """
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-    return CourseWaffleFlag(WAFFLE_NAMESPACE, ENABLE_EXTERNAL_CONFIG_FILTER, __name__)
+    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_CONFIG_FILTER}', __name__)
 
 
 def run_xblock_handler(*args, **kwargs):


### PR DESCRIPTION
This update caused by removing support for the LegacyWaffle* classes.
See https://github.com/openedx/public-engineering/issues/28 for details.