### PR TITLE
feat: add event tracking to lti launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,10 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+4.0.1 - 2022-06-27
+------------------
+* Add event tracking to LTI launches
+
 4.0.1 - 2022-05-09
 ------------------
 * Add `Learner` to LTI launch roles in addition to the `Student` value

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.1.1'
+__version__ = '4.2.1'

--- a/lti_consumer/lti_1p1/contrib/django.py
+++ b/lti_consumer/lti_1p1/contrib/django.py
@@ -5,7 +5,7 @@ This module provides functionality for rendering an LTI embed without an XBlock.
 # See comment in docstring for explanation of the usage of ResourceLoader
 from xblockutils.resources import ResourceLoader
 
-from lti_consumer.utils import track_event
+from lti_consumer.track import track_event
 
 from ..consumer import LtiConsumer1p1
 

--- a/lti_consumer/lti_1p1/contrib/django.py
+++ b/lti_consumer/lti_1p1/contrib/django.py
@@ -5,6 +5,8 @@ This module provides functionality for rendering an LTI embed without an XBlock.
 # See comment in docstring for explanation of the usage of ResourceLoader
 from xblockutils.resources import ResourceLoader
 
+from lti_consumer.utils import track_event
+
 from ..consumer import LtiConsumer1p1
 
 
@@ -122,6 +124,14 @@ def lti_embed(
         'element_id': html_element_id
     }
     context.update({'lti_parameters': lti_parameters})
+
+    # emit tracking event
+    event = {
+        'lti_version': lti_parameters.get('lti_version'),
+        'user_roles': lti_parameters.get('roles'),
+        'launch_url': lti_consumer.lti_launch_url,
+    }
+    track_event('embed.launch_request', event)
 
     # Render the form template and return the template
     loader = ResourceLoader(__name__)

--- a/lti_consumer/lti_1p1/contrib/tests/test_django.py
+++ b/lti_consumer/lti_1p1/contrib/tests/test_django.py
@@ -31,7 +31,7 @@ class TestLtiEmbed(TestCase):
         # Patch calls to LMS event tracking
         self._mock_emit_track_event = Mock()
         track_event_patcher = patch(
-            'lti_consumer.utils.get_event_tracker',
+            'lti_consumer.track.get_event_tracker',
             return_value=Mock(emit=self._mock_emit_track_event),
         )
         self.addCleanup(track_event_patcher.stop)

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -82,7 +82,7 @@ from .lti_1p3.exceptions import (
 )
 from .lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from .outcomes import OutcomeService
-from .utils import _, resolve_custom_parameter_template, external_config_filter_enabled
+from .utils import _, resolve_custom_parameter_template, external_config_filter_enabled, track_event
 
 
 log = logging.getLogger(__name__)
@@ -1094,6 +1094,15 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 log.exception('Error in XBlock LTI parameter processor "%s"', processor)
 
         lti_parameters = lti_consumer.generate_launch_request(self.resource_link_id)
+
+        # emit tracking event
+        event = {
+            'lti_version': lti_parameters.get('lti_version'),
+            'user_roles': lti_parameters.get('roles'),
+            'launch_url': lti_consumer.lti_launch_url,
+        }
+        track_event('xblock.launch_request', event)
+
         loader = ResourceLoader(__name__)
         context = self._get_context_for_template()
         context.update({'lti_parameters': lti_parameters})

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -82,7 +82,8 @@ from .lti_1p3.exceptions import (
 )
 from .lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from .outcomes import OutcomeService
-from .utils import _, resolve_custom_parameter_template, external_config_filter_enabled, track_event
+from .track import track_event
+from .utils import _, resolve_custom_parameter_template, external_config_filter_enabled
 
 
 log = logging.getLogger(__name__)

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1199,6 +1199,14 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 )
             })
 
+            # emit tracking event
+            event = {
+                'lti_version': self.lti_version,
+                'user_roles': user_role,
+                'launch_url': self.lti_1p3_launch_url,
+            }
+            track_event('xblock.launch_request', event)
+
             template = loader.render_mako_template('/templates/html/lti_1p3_launch.html', context)
             return Response(template, content_type='text/html')
         except Lti1p3Exception as exc:

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -227,3 +227,15 @@ def clean_course_id(model_form: ModelForm) -> CourseKey:
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.lib.courses import clean_course_id as lms_clean_course_id
     return lms_clean_course_id(model_form)
+
+
+def get_event_tracker():
+    """
+    Import and return LMS event tracking function
+    """
+    try:
+        # pylint: disable=import-outside-toplevel
+        from eventtracking import tracker
+        return tracker
+    except ModuleNotFoundError:
+        return None

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -45,7 +45,7 @@ class TestLtiConsumerXBlock(TestCase):
         # Patch calls to LMS event tracking
         self._mock_emit_track_event = Mock()
         track_event_patcher = patch(
-            'lti_consumer.utils.get_event_tracker',
+            'lti_consumer.track.get_event_tracker',
             return_value=Mock(emit=self._mock_emit_track_event),
         )
         self.addCleanup(track_event_patcher.stop)

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -42,6 +42,15 @@ class TestLtiConsumerXBlock(TestCase):
         }
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
 
+        # Patch calls to LMS event tracking
+        self._mock_emit_track_event = Mock()
+        track_event_patcher = patch(
+            'lti_consumer.utils.get_event_tracker',
+            return_value=Mock(emit=self._mock_emit_track_event),
+        )
+        self.addCleanup(track_event_patcher.stop)
+        track_event_patcher.start()
+
 
 class TestIndexibility(TestCase):
     """
@@ -662,7 +671,14 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
 
     def setUp(self):
         super().setUp()
-        self.mock_lti_consumer = Mock(generate_launch_request=Mock(return_value={}))
+        self.mock_lti_consumer = Mock(
+            lti_launch_url='https://test.co',
+            generate_launch_request=Mock(return_value={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI_1p3',
+                'roles': 'Student',
+            })
+        )
         self.xblock._get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
         self.xblock.due = timezone.now()
         self.xblock.graceperiod = timedelta(days=1)
@@ -694,6 +710,28 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
         self.mock_lti_consumer.generate_launch_request.assert_called_with(self.xblock.resource_link_id)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, 'text/html')
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.user_id', PropertyMock(return_value=FAKE_USER_ID))
+    def test_publish_tracking_event(self, mock_course):
+        """
+        Test a tracking event is emitted when generating a launch request
+        """
+        provider = 'lti_provider'
+        key = 'test'
+        secret = 'secret'
+        type(mock_course).lti_passports = PropertyMock(return_value=[f"{provider}:{key}:{secret}"])
+
+        request = make_request('', 'GET')
+        self.xblock.lti_launch_handler(request)
+        self._mock_emit_track_event.assert_called_with(
+            'edx.lti.xblock.launch_request',
+            {
+                'lti_version': 'LTI_1p3',
+                'user_roles': 'Student',
+                'launch_url': 'https://test.co',
+            }
+        )
 
 
 class TestOutcomeServiceHandler(TestLtiConsumerXBlock):

--- a/lti_consumer/track.py
+++ b/lti_consumer/track.py
@@ -1,0 +1,14 @@
+"""
+Tracking for analytics events
+"""
+from lti_consumer.plugin.compat import get_event_tracker
+
+
+def track_event(event_name, data):
+    """
+    Track analytics event. Fail silently if no tracking module present
+    """
+    tracker = get_event_tracker()
+    if tracker:
+        event_name = '.'.join(['edx', 'lti', event_name])
+        tracker.emit(event_name, data)

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -6,7 +6,7 @@ from importlib import import_module
 
 from django.conf import settings
 
-from lti_consumer.plugin.compat import get_external_config_waffle_flag
+from lti_consumer.plugin.compat import get_event_tracker, get_external_config_waffle_flag
 
 log = logging.getLogger(__name__)
 
@@ -164,3 +164,13 @@ def external_config_filter_enabled(course_key):
         course_key (opaque_keys.edx.locator.CourseLocator): Course Key
     """
     return get_external_config_waffle_flag().is_enabled(course_key)
+
+
+def track_event(event_name, data):
+    """
+    Track analytics event. Fail silently if no tracking module present
+    """
+    tracker = get_event_tracker()
+    if tracker:
+        event_name = '.'.join(['edx', 'lti', event_name])
+        tracker.emit(event_name, data)

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -6,7 +6,7 @@ from importlib import import_module
 
 from django.conf import settings
 
-from lti_consumer.plugin.compat import get_event_tracker, get_external_config_waffle_flag
+from lti_consumer.plugin.compat import get_external_config_waffle_flag
 
 log = logging.getLogger(__name__)
 
@@ -164,13 +164,3 @@ def external_config_filter_enabled(course_key):
         course_key (opaque_keys.edx.locator.CourseLocator): Course Key
     """
     return get_external_config_waffle_flag().is_enabled(course_key)
-
-
-def track_event(event_name, data):
-    """
-    Track analytics event. Fail silently if no tracking module present
-    """
-    tracker = get_event_tracker()
-    if tracker:
-        event_name = '.'.join(['edx', 'lti', event_name])
-        tracker.emit(event_name, data)


### PR DESCRIPTION
Track lti launch request events with the LMS event tracking library. This should fail silently if used outside the LMS.

### [MST-1506](https://2u-internal.atlassian.net/browse/MST-1506?atlOrigin=eyJpIjoiOGZmOThmYzlhMjJjNDNiMmIzMzFlMjAzZTU5ZDc4NjciLCJwIjoiaiJ9)