### PR TITLE
fix: Change user from None to AnonymousUser in authenticated requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,7 +369,11 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
-4.0.1 - 2022-06-27
+4.2.2 - 2022-06-30
+------------------
+* Fix server 500 error when using names/roles and grades services, due to not returning a user during auth.
+
+4.2.1 - 2022-06-27
 ------------------
 * Add event tracking to LTI launches
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.2.1'
+__version__ = '4.2.2'

--- a/lti_consumer/lti_1p3/extensions/rest_framework/authentication.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/authentication.py
@@ -3,6 +3,7 @@ Django REST Framework extensions for LTI 1.3 & LTI Advantage implementation.
 
 Implements a custom authentication class to be used by LTI Advantage extensions.
 """
+from django.contrib.auth.models import AnonymousUser
 from django.utils.translation import gettext as _
 from rest_framework import authentication
 from rest_framework import exceptions
@@ -74,6 +75,8 @@ class Lti1p3ApiAuthentication(authentication.BaseAuthentication):
         request.lti_configuration = lti_configuration
         request.lti_consumer = lti_consumer
 
-        # Return (None, None) since this isn't tied to any authentication
-        # backend on Django, and it's just used for LTI endpoints.
-        return (None, None)
+        # This isn't tied to any authentication backend on Django (it's just
+        # used for LTI endpoints), but we need to return some kind of User
+        # object or it will break edx-platform middleware that assumes it can
+        # introspect a user object on the request (e.g. DarkLangMiddleware).
+        return (AnonymousUser(), None)


### PR DESCRIPTION
Modified the Lti1p3ApiAuthentication authentication backend to return
AnonymousUser instead of None. This allows DarkLangMiddleware to work
properly without crashing when middleware tries to get a user info
from the request.

This investigation and patch was originally done by @OlhaShyliaieva in:
  https://github.com/openedx/xblock-lti-consumer/pull/228

I'm just rebasing it onto the latest version to land this change.