### PR TITLE
test: add debugging log statements for user_id LtiError

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.3.1'
+__version__ = '4.3.2'


### PR DESCRIPTION
This commit adds supplemental logging to diagnose the bug reported in [MST-1540](https://2u-internal.atlassian.net/browse/MST-1540). The bug is that learners are encountering the `LtiError` when trying to do an LTI launch. The learners appear to be authenticated, so this error should not occur. The bug is not easily reproducible in production or development, so this supplemental logging is added to help understand the user's state when the error is raised.

The current hypothesis is that user is temporarily represented by the AnonymousUser in the request that is made when doing the LTI launch, despite the user otherwise being authenticated. Logging in Splunk suggests that this is the case, because logs are of the following form, 

`2022-07-22 15:10:14,214 ERROR 5067 [django.request] [user None] [ip <ip>] log.py:224 - Internal Server Error: /courses/<course_key>/xblock/<usage_key>/handler/lti_launch_handler`,

where the "user" is "None". This logging should prove or disprove this hypothesis and provide direction about where else to look.

This logging should be removed once [MST-1540](https://2u-internal.atlassian.net/browse/MST-1540) is resolved.