### PR TITLE
fix: missing exception details in logs

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.3.2'
+__version__ = '4.3.3'

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -363,7 +363,7 @@ class LtiConsumer1p3:
         # Check if all required claims are present
         for required_claim in LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS:
             if required_claim not in token_request_data.keys():
-                raise exceptions.MissingRequiredClaim()
+                raise exceptions.MissingRequiredClaim(f'The required claim {required_claim} is missing from the JWT.')
 
         # Check that grant type is `client_credentials`
         if token_request_data['grant_type'] != 'client_credentials':

--- a/lti_consumer/lti_1p3/exceptions.py
+++ b/lti_consumer/lti_1p3/exceptions.py
@@ -6,11 +6,20 @@ Custom exceptions for LTI 1.3 consumer
 
 
 class Lti1p3Exception(Exception):
-    pass
+    """
+    This is the base exception for LTI 1.3 related exceptions. LTI 1.3 exceptions should extend this class to provide
+    greater detail about the exception.
+    """
+    message = None
+
+    def __init__(self, message=None):
+        if not message:
+            message = self.message
+        super().__init__(message)
 
 
 class TokenSignatureExpired(Lti1p3Exception):
-    pass
+    message = "The token signature has expired."
 
 
 class UnauthorizedToken(Lti1p3Exception):
@@ -18,7 +27,7 @@ class UnauthorizedToken(Lti1p3Exception):
 
 
 class NoSuitableKeys(Lti1p3Exception):
-    pass
+    message = "JWKS could not be loaded from the URL."
 
 
 class UnknownClientId(Lti1p3Exception):
@@ -26,40 +35,40 @@ class UnknownClientId(Lti1p3Exception):
 
 
 class MalformedJwtToken(Lti1p3Exception):
-    pass
+    message = "The JWT could not be parsed because it is malformed."
 
 
 class MissingRequiredClaim(Lti1p3Exception):
-    pass
+    message = "The required claim is missing."
 
 
 class UnsupportedGrantType(Lti1p3Exception):
-    pass
+    message = "The JWT grant_type is unsupported."
 
 
 class InvalidClaimValue(Lti1p3Exception):
-    pass
+    message = "The claim has an invalid value."
 
 
 class InvalidRsaKey(Lti1p3Exception):
-    pass
+    message = "The RSA key could not parsed."
 
 
 class RsaKeyNotSet(Lti1p3Exception):
-    pass
+    message = "The RSA key is not set."
 
 
 class PreflightRequestValidationFailure(Lti1p3Exception):
-    pass
+    message = "The preflight response is not valid."
 
 
 class LtiAdvantageServiceNotSetUp(Lti1p3Exception):
-    pass
+    message = "The LTI Advantage Service is not set up."
 
 
 class LtiNrpsServiceNotSetUp(Lti1p3Exception):
-    pass
+    message = "LTI Names and Role Provisioning Services is not set up."
 
 
 class LtiDeepLinkingContentTypeNotSupported(Lti1p3Exception):
-    pass
+    message = "The content_type is not supported by LTI Deep Linking."

--- a/lti_consumer/lti_1p3/key_handlers.py
+++ b/lti_consumer/lti_1p3/key_handlers.py
@@ -122,9 +122,7 @@ class ToolKeyHandler:
 
         except NoSuitableSigningKeys as err:
             raise exceptions.NoSuitableKeys() from err
-        except BadSyntax as err:
-            raise exceptions.MalformedJwtToken() from err
-        except WrongNumberOfParts as err:
+        except (BadSyntax, WrongNumberOfParts) as err:
             raise exceptions.MalformedJwtToken() from err
 
 
@@ -208,12 +206,13 @@ class PlatformKeyHandler:
             # Validate issuer claim (if present)
             if iss:
                 if 'iss' not in message or message['iss'] != iss:
-                    raise exceptions.InvalidClaimValue()
+                    raise exceptions.InvalidClaimValue('The required iss claim is either missing or does '
+                                                       'not match the expected iss value.')
 
             # Validate audience claim (if present)
             if aud:
                 if 'aud' not in message or aud not in message['aud']:
-                    raise exceptions.InvalidClaimValue()
+                    raise exceptions.InvalidClaimValue('The required aud claim is missing.')
 
             # Else return token contents
             return message

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1271,11 +1271,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
             template = loader.render_mako_template('/templates/html/lti_1p3_launch.html', context)
             return Response(template, content_type='text/html')
-        except (Lti1p3Exception, NotImplementedError) as exc:
+        except (Lti1p3Exception, LtiError, NotImplementedError, TypeError, ValueError) as exc:
             log.warning(
                 "Error preparing LTI 1.3 launch for block %r: %s",
                 str(self.location),  # pylint: disable=no-member
                 exc,
+                exc_info=True,
             )
             template = loader.render_django_template('/templates/html/lti_1p3_launch_error.html', context)
             return Response(template, status=400, content_type='text/html')
@@ -1285,6 +1286,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 str(self.location),  # pylint: disable=no-member
                 self.external_user_id,
                 exc,
+                exc_info=True
             )
             template = loader.render_django_template('/templates/html/lti_1p3_permission_error.html', context)
             return Response(template, status=403, content_type='text/html')


### PR DESCRIPTION
The error handler in `LtiConsumerXBlock.lti_1p3_launch_callback` logs a warning when a select set of exceptions are handled. That log does not contain useful information about the nature of the exception, because the exceptions were not being instantiated with error messages. The try...catch is a large block that contains code that can raise a multitude of errors, so these changes will enable better debugging.

This commit:
* adds helpful messages to the raised exceptions.
* adds the `exc_info=True` argument to include the stack trace of the handled exception.
* adds `ValueError` and `TypeError` to the list of handled exceptions, because the code can raise exceptions of these types.

This is a sample log before.

```
2022-08-01 21:26:51,992 WARNING 5544 [lti_consumer.lti_xblock] [user 3] [ip 172.28.0.1] lti_xblock.py:1278 - Error preparing LTI 1.3 launch for block 'block-v1:edX+DemoX+Demo_Course+type@lti_consumer+block@b98a9382452540a686b6f9de5e619cf1': 
```

This is a sample log after.

```
2022-08-02 13:17:27,727 WARNING 5974 [lti_consumer.lti_xblock] [user 3] [ip 172.28.0.1] lti_xblock.py:1277 - Error preparing LTI 1.3 launch for block 'block-v1:edX+DemoX+Demo_Course+type@lti_consumer+block@b98a9382452540a686b6f9de5e619cf1': The content_type is not supported by LTI Deep Linking.
Traceback (most recent call last):
  File "/edx/src/xblock-lti-consumer/lti_consumer/lti_xblock.py", line 1233, in lti_1p3_launch_callback
    lti_consumer.lti_dl.get_lti_deep_linking_launch_claim(accept_types='gibberish')
  File "/edx/src/xblock-lti-consumer/lti_consumer/lti_1p3/deep_linking.py", line 45, in get_lti_deep_linking_launch_claim
    raise exceptions.LtiDeepLinkingContentTypeNotSupported('The content_type is not supported by LTI '
lti_consumer.lti_1p3.exceptions.LtiDeepLinkingContentTypeNotSupported: The content_type is not supported by LTI Deep Linking.
```