### PR TITLE
Handle LtiError Error During LTI 1.1 Launch for Unauthenticated User

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.4.0'
+__version__ = '4.5.0'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -791,27 +791,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'edx-platform.anonymous_user_id', None)
 
         if user_id is None:
-            # TODO: Remove the supplemental log messaging. The logs were amended to help diagnose the bug in MST-1540:
-            # https://2u-internal.atlassian.net/browse/MST-1540. The bug is not easily reproducible in production or
-            # development, so these logs were added to determine whether the currently requesting user is an
-            # AnonymousUser or a currently authenticated user.
-            # pylint: disable=import-outside-toplevel
-            from crum import get_current_request
-            request = get_current_request()
-
-            # A test (lti_consumer.tests.unit.test_lti_xblock.TestProperties.test_user_id_none) calls this function
-            # directly, outside the scope of a request, causing it to fail if we assume this function runs within the
-            # context of a request. It's easier to modify the code here to handle the case when there is no request
-            # object to appease the test than to modify the test, because these changes to the log are temporary and
-            # will be removed shortly.
-            request_user_id = None
-            request_user_authenticated = None
-            if request:
-                request_user_id = request.user.id
-                request_user_authenticated = request.user.is_authenticated
-            raise LtiError(self.ugettext(f"Could not get user id for current request"
-                                         f" and currently requesting user id is: {request_user_id}"
-                                         f" and is_authenticated is: {request_user_authenticated}"))
+            raise LtiError(self.ugettext("Could not get user id for current request"))
         return str(user_id)
 
     def get_icon_class(self):

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -150,7 +150,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
     usage_id = request.GET.get('login_hint')
     if not usage_id:
         log.info('The `login_hint` query param in the request is missing or empty.')
-        return render(request, 'html/lti_1p3_launch_error.html', status=HTTP_400_BAD_REQUEST)
+        return render(request, 'html/lti_launch_error.html', status=HTTP_400_BAD_REQUEST)
 
     try:
         usage_key = UsageKey.from_string(usage_id)
@@ -161,7 +161,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
             exc,
             exc_info=True
         )
-        return render(request, 'html/lti_1p3_launch_error.html', status=HTTP_404_NOT_FOUND)
+        return render(request, 'html/lti_launch_error.html', status=HTTP_404_NOT_FOUND)
 
     try:
         lti_config = LtiConfiguration.objects.get(
@@ -173,7 +173,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
 
     if lti_config.version != LtiConfiguration.LTI_1P3:
         log.error("The LTI Version of configuration %s is not LTI 1.3", lti_config)
-        return render(request, 'html/lti_1p3_launch_error.html', status=HTTP_404_NOT_FOUND)
+        return render(request, 'html/lti_launch_error.html', status=HTTP_404_NOT_FOUND)
 
     context = {}
 
@@ -269,7 +269,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
             exc,
             exc_info=True
         )
-        return render(request, 'html/lti_1p3_launch_error.html', context, status=HTTP_400_BAD_REQUEST)
+        return render(request, 'html/lti_launch_error.html', context, status=HTTP_400_BAD_REQUEST)
     except AssertionError as exc:
         log.warning(
             "Permission on LTI block %r denied for user %r: %s",

--- a/lti_consumer/templates/html/lti_launch_error.html
+++ b/lti_consumer/templates/html/lti_launch_error.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <p>
-            <b>{% trans "There was an error while launching the LTI 1.3 tool." %}</b>
+            <b>{% trans "There was an error while launching the LTI tool." %}</b>
         </p>
         <p>
             {% trans "If you're seeing this on a live course, please contact the course staff." %}

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -196,7 +196,7 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         self.assertEqual(response.status_code, 400)
 
         response_body = response.content.decode('utf-8')
-        self.assertIn("There was an error while launching the LTI 1.3 tool.", response_body)
+        self.assertIn("There was an error while launching the LTI tool.", response_body)
         self.assertNotIn("% trans", response_body)
 
         with patch(


### PR DESCRIPTION
[[MST-1585]](https://2u-internal.atlassian.net/browse/MST-1585)

**Description**

In the LTI 1.1 launch handler, we set the user context, including the `user_id`. We do this by calling to the LMS's `DjangoXBlockUserService` to get information about the user. Sometimes, the user is unauthenticated. Sometimes, this is because the user is a web crawler. Other times, the user is a real user, but we do not know why the user is unauthenticated. We have some theories, but we have been unable to confirm them. Regardless, we should not surface a 500 error to the user.

This pull request adds handling for the `LtiError` that is raised when a user is unauthenticated during an LTI 1.1 launch. It catches the `LtiError` and renders an error page. The error page that was used for LTI 1.3 launches, formerly named `lti_1p3_launch_error.html`, has been renamed to `lti_launch_error.html` to reflect the fact that it is used for both LTI 1.1 and 1.3 launches. It was modified to remove the reference to the version of LTI used by the XBlock; these details are unnecessary for a learner, and removing them allows us to reuse a single template for both LTI versions.

This pull request also reverts a previous commit that added additional logging to help investigate the error.

The below photos are from devstack, so the UI looks a little different because debug mode is on.

**Before**

**Modal Launch**

<img width="1416" alt="Screen Shot 2022-08-19 at 8 32 21 AM" src="https://user-images.githubusercontent.com/11871801/185621493-c45ca7b2-1c7f-475e-bda9-3185dfcd7932.png">

**New Window Launch**

<img width="1424" alt="Screen Shot 2022-08-19 at 8 36 48 AM" src="https://user-images.githubusercontent.com/11871801/185621578-a82f0c2a-441f-486d-93bf-d76449fc0825.png">

**After**

**Modal Launch**

<img width="1425" alt="Screen Shot 2022-08-19 at 8 38 46 AM" src="https://user-images.githubusercontent.com/11871801/185621604-8f3349bd-7509-4fb6-ae37-54a1e7791454.png">

**New Window Launch**

<img width="1432" alt="Screen Shot 2022-08-19 at 8 37 24 AM" src="https://user-images.githubusercontent.com/11871801/185621638-dd0141a7-f31d-48a0-a2b7-1051c3ea7450.png">