### PR TITLE
feat: decouple LTI 1.3 launch from the XBlockLtiConsumer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,27 @@ Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/release
 Unreleased
 ~~~~~~~~~~
 
+5.0.0 - 2022-10-12
+------------------
+BREAKING CHANGE:
+
+Please note that additional breaking changes will be forthcoming in future versions of this library.
+
+* Modified Python API methods to take Lti1p3LaunchData as a required argument
+** get_lti_1p3_launch_info
+** get_lti_1p3_launch_start_url
+** get_lti_1p3_content_url
+
+* Added an Lti1p3LaunchData data class
+* Added caching for Lti1p3LaunchData to limit data sent in request query or form parameters
+* Replaced references to LtiConsumerXBlock.location with Lti1p3LaunchData.config_id
+* Removed definition of key LTI 1.3 claims from the launch_gate_endpoint and instantiated Lti1p3LaunchData from within
+  the LtiConsumerXBlock instead
+* Added a required launch_data_key request query parameter to the deep_linking_content_endpoint and refactored
+  associated templates and template tags to pass this parameter in the request to the view
+* Changed the access token URL and Keyset URL to use the LtiConfiguration.config_id in the URL instead of the
+  LtiConfiguration.location
+
 4.4.0 - 2022-08-17
 ------------------
 * Move the LTI 1.3 Access Token and Launch Callback endpoint logic from the XBlock to the Django views

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.5.0'
+__version__ = '5.0.0'

--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -1,0 +1,46 @@
+"""
+This modules provides public data structures to represent LTI 1.3 launch data that can be used within this library and
+by users of this library.
+"""
+
+from attrs import define, field
+
+
+@define
+class Lti1p3LaunchData:
+    """
+    The Lti1p3LaunchData class contains data necessary and related to an LTI 1.3 launch. It is a mechanism to share
+    launch data between apps. Applications using this library should use the Lti1p3LaunchData class to supply
+    contextually defined or stored launch data to the generic LTI 1.3 launch.
+
+    * user_id (required): the user's unique identifier
+    * user_role (required): the user's role as one of the keys in LTI_1P3_ROLE_MAP: staff, instructor, student, or
+        guest
+    * config_id (required): the config_id field of an LtiConfiguration to use for the launch
+    * resource_link_id (required): a unique identifier that is guaranteed to be unique for each placement of the LTI
+        link
+    * launch_presentation_document_target (optional): the document_target property of the launch_presentation claim; it
+        describes the kind of browser window or frame from which the user launched inside the message sender's system;
+        it is one of frame, iframe, or window; it defaults to iframe
+    * message_type (optional): the message type of the eventual LTI launch; defaults to LtiResourceLinkRequest
+    * context_id (conditionally required): the id property of the context claim; the stable, unique identifier for the
+        context; if any of the context properties are provided, context_id is required
+    * context_type (optional): the type property of the context claim; a list of some combination of the following valid
+        context_types: group, course_offering, course_section, or course_template
+    * context_title (optional): the title proerty of the context claim; a short, descriptive name for the context
+    * context_label (optional): the label property of the context claim; a full, descriptive name for the context
+    * deep_linking_context_item_id (optional): the database id of the LtiDlContentItem that should be used for the LTI
+        1.3 Deep Linking launch; this is used when the LTI 1.3 Deep Linking launch is a regular LTI resource link
+        request using a content item that was configured via a previous LTI 1.3 Deep Linking request
+    """
+    user_id = field()
+    user_role = field()
+    config_id = field()
+    resource_link_id = field()
+    launch_presentation_document_target = field(default="iframe")
+    message_type = field(default="LtiResourceLinkRequest")
+    context_id = field(default=None)
+    context_type = field(default=None)
+    context_title = field(default=None)
+    context_label = field(default=None)
+    deep_linking_content_item_id = field(default=None)

--- a/lti_consumer/lti_1p1/tests/test_consumer.py
+++ b/lti_consumer/lti_1p1/tests/test_consumer.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 from lti_consumer.lti_1p1.exceptions import Lti1p1Error
 from lti_consumer.lti_1p1.consumer import LtiConsumer1p1, parse_result_json
-from lti_consumer.tests.unit.test_utils import make_request
+from lti_consumer.tests.test_utils import make_request
 
 INVALID_JSON_INPUTS = [
     ([

--- a/lti_consumer/lti_1p1/tests/test_oauth.py
+++ b/lti_consumer/lti_1p1/tests/test_oauth.py
@@ -10,7 +10,7 @@ from lti_consumer.lti_1p1.exceptions import Lti1p1Error
 from lti_consumer.lti_1p1.oauth import (get_oauth_request_signature,
                                         log_authorization_header,
                                         verify_oauth_body_signature)
-from lti_consumer.tests.unit.test_utils import make_request
+from lti_consumer.tests.test_utils import make_request
 
 OAUTH_PARAMS = [
     ('oauth_nonce', '80966668944732164491378916897'),

--- a/lti_consumer/lti_1p3/exceptions.py
+++ b/lti_consumer/lti_1p3/exceptions.py
@@ -62,6 +62,10 @@ class PreflightRequestValidationFailure(Lti1p3Exception):
     message = "The preflight response is not valid."
 
 
+class LtiLaunchDataValidationFailure(Lti1p3Exception):
+    message = "The Lti1p3LaunchData is not valid."
+
+
 class LtiAdvantageServiceNotSetUp(Lti1p3Exception):
     message = "The LTI Advantage Service is not set up."
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -258,22 +258,3 @@ def get_event_tracker():
         return tracker
     except ModuleNotFoundError:
         return None
-
-
-def get_user_role(user, course_key: CourseKey) -> str:
-    """
-    Import the get_user_role from LMS and return the value.
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from lms.djangoapps.courseware.access import get_user_role as get_role
-    return get_role(user, course_key)
-
-
-def get_external_id_for_user(user) -> str:
-    """
-    Import and run `get_external_id_for_user` from LMS
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from openedx.core.djangoapps.external_user_ids.models import ExternalId
-    ext_user, _ = ExternalId.add_new_user_id(user, 'lti')
-    return str(ext_user.external_user_id)

--- a/lti_consumer/templates/html/lti-dl/render_dl_content.html
+++ b/lti_consumer/templates/html/lti-dl/render_dl_content.html
@@ -8,7 +8,7 @@
         {% for item in content_items %}
             <div>
                 {% if item.content_type == 'ltiResourceLink' %}
-                    {% include "html/lti-dl/render_lti_resource_link.html" with item=item attrs=item.attributes %}
+                    {% include "html/lti-dl/render_lti_resource_link.html" with item=item attrs=item.attributes launch_data=launch_data %}
                 {% elif item.content_type == 'link' %}
                     {% include "html/lti-dl/render_link.html" with item=item attrs=item.attributes %}
                 {% elif item.content_type == 'html' %}

--- a/lti_consumer/templates/html/lti-dl/render_lti_resource_link.html
+++ b/lti_consumer/templates/html/lti-dl/render_lti_resource_link.html
@@ -3,7 +3,9 @@
 {% if attrs.title %}<h2>{{ attrs.title }}</h2>{% endif %}
 {% if attrs.text %}<p>{{ attrs.text }}</p>{% endif %}
 
-<a href="{{ item | get_dl_lti_launch_url }}" target="_blank">
+{% get_dl_lti_launch_url item launch_data as launch_url %}
+
+<a href="{{ launch_url }}" target="_blank">
     Click here to launch the LTI content in a new tab
     <i class="icon fa fa-external-link"></i>
 </a>

--- a/lti_consumer/templatetags/get_dl_lti_launch_url.py
+++ b/lti_consumer/templatetags/get_dl_lti_launch_url.py
@@ -4,23 +4,22 @@ Template tags and helper functions for sanitizing html.
 from django import template
 from lti_consumer.api import get_lti_1p3_launch_start_url
 
-
 register = template.Library()
 
 
-@register.filter()
-def get_dl_lti_launch_url(content_item):
+@register.simple_tag
+def get_dl_lti_launch_url(content_item, launch_data):
     """
-    Template tag to retrive the LTI launch URL for `ltiResourceLink` content.
+    Template tag to retrieve the LTI launch URL for `ltiResourceLink` content.
 
-    This uses the LTI Consumer API, but hardcodes the `hint` parameter to the
-    block id (used when LTI launches are tied to XBlocks).
+    This uses the LTI Consumer API to generate the LTI 1.3 third party login initiation
+    URL to start the LTI 1.3 launch flow.
 
-    TODO: Refactor `hint` to use generic ID once LTI launches out of XBlocks are
-    supported.
+    This template tag requires content_item and launch_data arguments, which are passed to
+    get_lti_1p3_launch_start_url to encode information necessary to the eventual LTI 1.3 launch.
     """
     return get_lti_1p3_launch_start_url(
+        launch_data,
         config_id=content_item.lti_configuration.id,
         dl_content_id=content_item.id,
-        hint=str(content_item.lti_configuration.location),
     )

--- a/lti_consumer/tests/test_utils.py
+++ b/lti_consumer/tests/test_utils.py
@@ -1,0 +1,96 @@
+"""
+Utility functions used within unit tests
+"""
+
+from unittest.mock import Mock
+import urllib
+
+from opaque_keys.edx.keys import UsageKey
+from webob import Request
+from workbench.runtime import WorkbenchRuntime
+from xblock.fields import ScopeIds
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+
+
+FAKE_USER_ID = 'fake_user_id'
+
+
+def make_xblock(xblock_name, xblock_cls, attributes):
+    """
+    Helper to construct XBlock objects
+    """
+    runtime = WorkbenchRuntime()
+    key_store = DictKeyValueStore()
+    db_model = KvsFieldData(key_store)
+    ids = generate_scope_ids(runtime, xblock_name)
+    xblock = xblock_cls(runtime, db_model, scope_ids=ids)
+    xblock.category = Mock()
+
+    xblock.location = UsageKey.from_string(
+        'block-v1:edX+DemoX+Demo_Course+type@problem+block@466f474fa4d045a8b7bde1b911e095ca'
+    )
+
+    xblock.runtime = Mock(
+        hostname='localhost',
+    )
+    xblock.course_id = 'course-v1:edX+DemoX+Demo_Course'
+    for key, value in attributes.items():
+        setattr(xblock, key, value)
+    return xblock
+
+
+def generate_scope_ids(runtime, block_type):
+    """
+    Helper to generate scope IDs for an XBlock
+    """
+    def_id = runtime.id_generator.create_definition(block_type)
+    usage_id = runtime.id_generator.create_usage(def_id)
+    return ScopeIds('user', block_type, def_id, usage_id)
+
+
+def make_request(body, method='POST'):
+    """
+    Helper to make a request
+    """
+    request = Request.blank('/')
+    request.method = 'POST'
+    request.body = body.encode('utf-8')
+    request.method = method
+    return request
+
+
+def make_jwt_request(token, **overrides):
+    """
+    Builds a Request with a JWT body.
+    """
+    body = {
+        "grant_type": "client_credentials",
+        "client_assertion_type": "something",
+        "client_assertion": token,
+        "scope": "",
+    }
+    request = make_request(urllib.parse.urlencode({**body, **overrides}), 'POST')
+    request.content_type = 'application/x-www-form-urlencoded'
+    return request
+
+
+def dummy_processor(_xblock):
+    """
+    A dummy LTI parameter processor.
+    """
+    return {
+        'custom_author_email': 'author@example.com',
+        'custom_author_country': '',
+    }
+
+
+def defaulting_processor(_xblock):
+    """
+    A dummy LTI parameter processor with default params.
+    """
+
+
+defaulting_processor.lti_xblock_default_params = {
+    'custom_name': 'Lex',
+    'custom_country': '',
+}

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -15,7 +15,7 @@ from rest_framework.test import APITransactionTestCase
 
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration, LtiAgsLineItem, LtiAgsScore
-from lti_consumer.tests.unit.test_utils import make_xblock
+from lti_consumer.tests.test_utils import make_xblock
 
 
 class LtiAgsLineItemViewSetTestCase(APITransactionTestCase):
@@ -49,12 +49,9 @@ class LtiAgsLineItemViewSetTestCase(APITransactionTestCase):
         }
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
 
-        # Set dummy location so that UsageKey lookup is valid
-        self.xblock.location = 'block-v1:course+test+2020+type@problem+block@test'
-
         # Create configuration
         self.lti_config = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
         )
         # Preload XBlock to avoid calls to modulestore
@@ -177,7 +174,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
         line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
             resource_id="test",
-            resource_link_id=self.xblock.location,
+            resource_link_id=self.xblock.location,  # pylint: disable=no-member
             label="test label",
             score_maximum=100
         )
@@ -198,7 +195,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
                     'scoreMaximum': 100,
                     'label': 'test label',
                     'tag': '',
-                    'resourceLinkId': self.xblock.location,
+                    'resourceLinkId': str(self.xblock.location),  # pylint: disable=no-member
                     'startDateTime': None,
                     'endDateTime': None,
                 }
@@ -215,7 +212,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
         line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
             resource_id="test",
-            resource_link_id=self.xblock.location,
+            resource_link_id=self.xblock.location,  # pylint: disable=no-member
             label="test label",
             score_maximum=100
         )
@@ -242,7 +239,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
                 'scoreMaximum': 100,
                 'label': 'test label',
                 'tag': '',
-                'resourceLinkId': self.xblock.location,
+                'resourceLinkId': str(self.xblock.location),  # pylint: disable=no-member
                 'startDateTime': None,
                 'endDateTime': None,
             }
@@ -262,7 +259,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
                 'scoreMaximum': 100,
                 'label': 'test',
                 'tag': 'score',
-                'resourceLinkId': self.xblock.location,
+                'resourceLinkId': str(self.xblock.location),  # pylint: disable=no-member
             }),
             content_type="application/vnd.ims.lis.v2.lineitem+json",
         )
@@ -276,7 +273,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
                 'scoreMaximum': 100,
                 'label': 'test',
                 'tag': 'score',
-                'resourceLinkId': self.xblock.location,
+                'resourceLinkId': str(self.xblock.location),  # pylint: disable=no-member
                 'startDateTime': None,
                 'endDateTime': None,
             }
@@ -287,7 +284,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(line_item.score_maximum, 100)
         self.assertEqual(line_item.label, 'test')
         self.assertEqual(line_item.tag, 'score')
-        self.assertEqual(str(line_item.resource_link_id), self.xblock.location)
+        self.assertEqual(str(line_item.resource_link_id), str(self.xblock.location))  # pylint: disable=no-member
 
     def test_create_lineitem_invalid_resource_link_id(self):
         """
@@ -324,7 +321,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
             resource_id="test",
-            resource_link_id=self.xblock.location,
+            resource_link_id=self.xblock.location,  # pylint: disable=no-member
             label="test label",
             score_maximum=100
         )
@@ -856,7 +853,7 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
         self.line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
             resource_id="test",
-            resource_link_id=self.xblock.location,
+            resource_link_id=self.xblock.location,  # pylint: disable=no-member
             label="test label",
             score_maximum=100
         )

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -10,7 +10,7 @@ from rest_framework.reverse import reverse
 from lti_consumer.exceptions import LtiError
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration
-from lti_consumer.tests.unit.test_utils import make_xblock
+from lti_consumer.tests.test_utils import make_xblock
 
 
 def generate_mock_members(num, role='student'):
@@ -135,12 +135,9 @@ class LtiNrpsTestCase(APITransactionTestCase):
 
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
 
-        # Set dummy location so that UsageKey lookup is valid
-        self.xblock.location = 'block-v1:course+test+2020+type@problem+block@test'
-
         # Create configuration
         self.lti_config = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
         )
         # Preload XBlock to avoid calls to modulestore

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -3,7 +3,7 @@ Unit tests for LTI models.
 """
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from unittest.mock import patch, Mock, PropertyMock
+from unittest.mock import patch
 
 import ddt
 from Cryptodome.PublicKey import RSA
@@ -22,7 +22,7 @@ from lti_consumer.models import (
     LtiConfiguration,
     LtiDlContentItem,
 )
-from lti_consumer.tests.unit.test_utils import make_xblock
+from lti_consumer.tests.test_utils import make_xblock
 
 
 @ddt.ddt
@@ -54,22 +54,20 @@ class TestLtiConfigurationModel(TestCase):
             'lti_advantage_deep_linking_enabled': True,
         }
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
-        # Set dummy location so that UsageKey lookup is valid
-        self.xblock.location = 'block-v1:course+test+2020+type@problem+block@test'
 
         # Creates an LTI configuration objects for testing
         self.lti_1p1_config = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P1
         )
 
         self.lti_1p3_config = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3
         )
 
         self.lti_1p3_config_db = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
             config_store=LtiConfiguration.CONFIG_ON_DB,
             lti_advantage_ags_mode='programmatic',
@@ -92,7 +90,7 @@ class TestLtiConfigurationModel(TestCase):
         Helper function to create a LtiConfiguration object with specific attributes
         """
         return LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
             **kwargs
         )
@@ -385,10 +383,6 @@ class TestLtiConfigurationModel(TestCase):
         self.lti_1p3_config.config_store = self.lti_1p3_config.CONFIG_ON_DB
         self.lti_1p3_config.block = self.xblock
 
-        self.xblock.location = Mock()
-        course_key_mock = PropertyMock(return_value='course-v1:edX+DemoX+Demo_Course')
-        type(self.xblock.location).course_key = course_key_mock
-
         self.lti_1p3_config_db.block = self.xblock
 
         with patch("lti_consumer.models.database_config_enabled", return_value=False),\
@@ -495,11 +489,9 @@ class TestLtiDlContentItemModel(TestCase):
 
         self.xblock_attributes = {'lti_version': 'lti_1p3'}
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
-        # Set dummy location so that UsageKey lookup is valid
-        self.xblock.location = 'block-v1:course+test+2020+type@problem+block@test'
 
         self.lti_1p3_config = LtiConfiguration.objects.create(
-            location=str(self.xblock.location),
+            location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3
         )
 
@@ -507,6 +499,7 @@ class TestLtiDlContentItemModel(TestCase):
         """
         Test String representation of model.
         """
+
         content_item = LtiDlContentItem.objects.create(
             lti_configuration=self.lti_1p3_config,
             content_type=LtiDlContentItem.IMAGE,
@@ -514,7 +507,8 @@ class TestLtiDlContentItemModel(TestCase):
         )
         self.assertEqual(
             str(content_item),
-            "[CONFIG_ON_XBLOCK] lti_1p3 - block-v1:course+test+2020+type@problem+block@test: image"
+            "[CONFIG_ON_XBLOCK] lti_1p3 - "
+            "block-v1:edX+DemoX+Demo_Course+type@problem+block@466f474fa4d045a8b7bde1b911e095ca: image"
         )
 
 

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, PropertyMock, patch
 from lti_consumer.exceptions import LtiError
 from lti_consumer.outcomes import OutcomeService, parse_grade_xml_body
 from lti_consumer.tests.unit.test_lti_xblock import TestLtiConsumerXBlock
-from lti_consumer.tests.unit.test_utils import make_request
+from lti_consumer.tests.test_utils import make_request
 
 REQUEST_BODY_TEMPLATE_VALID = textwrap.dedent("""
     <?xml version="1.0" encoding="UTF-8"?>

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -3,10 +3,13 @@ Utility functions for LTI Consumer block
 """
 import logging
 from importlib import import_module
+from urllib.parse import urlencode
 
 from django.conf import settings
+from edx_django_utils.cache import get_cache_key, TieredCache
 
 from lti_consumer.plugin.compat import get_external_config_waffle_flag, get_database_config_waffle_flag
+from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 
 log = logging.getLogger(__name__)
 
@@ -30,15 +33,15 @@ def get_lms_base():
     return settings.LMS_ROOT_URL
 
 
-def get_lms_lti_keyset_link(location):
+def get_lms_lti_keyset_link(config_id):
     """
     Returns an LMS link to LTI public keyset endpoint
 
-    :param location: the location or config_id of the LtiConfiguration object
+    :param config_id: the config_id of the LtiConfiguration object
     """
-    return "{lms_base}/api/lti_consumer/v1/public_keysets/{location}".format(
+    return "{lms_base}/api/lti_consumer/v1/public_keysets/{config_id}".format(
         lms_base=get_lms_base(),
-        location=str(location),
+        config_id=str(config_id),
     )
 
 
@@ -53,15 +56,15 @@ def get_lms_lti_launch_link():
     )
 
 
-def get_lms_lti_access_token_link(location):
+def get_lms_lti_access_token_link(config_id):
     """
     Returns an LMS link to LTI Launch endpoint
 
-    :param location: the location or config_id of the LtiConfiguration object
+    :param config_id: the config_id of the LtiConfiguration object
     """
-    return "{lms_base}/api/lti_consumer/v1/token/{location}".format(
+    return "{lms_base}/api/lti_consumer/v1/token/{config_id}".format(
         lms_base=get_lms_base(),
-        location=str(location),
+        config_id=str(config_id),
     )
 
 
@@ -97,16 +100,26 @@ def get_lti_deeplinking_response_url(lti_config_id):
     )
 
 
-def get_lti_deeplinking_content_url(lti_config_id):
+def get_lti_deeplinking_content_url(lti_config_id, launch_data):
     """
     Return the LTI Deep Linking content presentation endpoint
 
     :param lti_config_id: LTI configuration id
+    :param launch_data: (lti_consumer.data.Lti1p3LaunchData): a class containing data necessary for an LTI 1.3 launch
     """
-    return "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-dl/content".format(
+    url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-dl/content".format(
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
+    url += "?"
+
+    launch_data_key = cache_lti_1p3_launch_data(launch_data)
+
+    url += urlencode({
+        "launch_data_key": launch_data_key,
+    })
+
+    return url
 
 
 def get_lti_nrps_context_membership_url(lti_config_id):
@@ -172,3 +185,82 @@ def database_config_enabled(course_key):
     return False if it is not enabled.
     """
     return get_database_config_waffle_flag().is_enabled(course_key)
+
+
+def get_lti_1p3_context_types_claim(context_types):
+    """
+    Return the LTI 1.3 context_type claim based on the context_type slug provided as an argument.
+
+    Arguments:
+        context_type (list): a list of context_types
+    """
+    lti_context_types = []
+
+    for context_type in context_types:
+        if context_type == "group":
+            lti_context_types.append(LTI_1P3_CONTEXT_TYPE.group)
+        elif context_type == "course_offering":
+            lti_context_types.append(LTI_1P3_CONTEXT_TYPE.course_offering)
+        elif context_type == "course_section":
+            lti_context_types.append(LTI_1P3_CONTEXT_TYPE.course_section)
+        elif context_type == "course_template":
+            lti_context_types.append(LTI_1P3_CONTEXT_TYPE.course_template)
+        else:
+            raise ValueError("context_type is not a valid type.")
+
+    return lti_context_types
+
+
+def get_lti_1p3_launch_data_cache_key(launch_data):
+    """
+    Return the cache key for the instance of Lti1p3LaunchData.
+
+    Arugments:
+        launch_data (lti_consumer.data.Lti1p3LaunchData): a class containing data necessary for an LTI 1.3 launch
+    """
+    kwargs = {
+        "app": "lti",
+        "key": "launch_data",
+        "user_id": launch_data.user_id,
+        "resource_link_id": launch_data.resource_link_id
+    }
+
+    # If the LTI 1.3 launch is a deep linking launch to a particular content item, then the launch data should be cached
+    # per content item to properly do an LTI 1.3 deep linking launch. Otherwise, deep linking launches to different
+    # items will not work via the deep_linking_content_endpoint view, because launch data is cached at the time that the
+    # preflight URL is generated.
+    content_item_id = launch_data.deep_linking_content_item_id
+    if content_item_id:
+        kwargs["deep_linking_content_item_id"] = content_item_id
+
+    return get_cache_key(**kwargs)
+
+
+def cache_lti_1p3_launch_data(launch_data):
+    """
+    Insert the launch_data into the cache and return the cache key.
+
+    Arguments:
+        launch_data (lti_consumer.data.Lti1p3LaunchData): a class containing data necessary for an LTI 1.3 launch
+    """
+    launch_data_key = get_lti_1p3_launch_data_cache_key(launch_data)
+
+    # Insert the data into the cache with a 600 second timeout.
+    TieredCache.set_all_tiers(launch_data_key, launch_data, django_cache_timeout=600)
+
+    return launch_data_key
+
+
+def get_data_from_cache(cache_key):
+    """
+    Return data stored in the cache with the cache key, if it exists. If not, return none.
+
+    Arguments:
+    cache_key: the key for the data in the cache
+    """
+    cached_data = TieredCache.get_cached_response(cache_key)
+
+    if cached_data.is_found:
+        return cached_data.value
+
+    return None

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,7 @@
 # Core requirements for using this package
 -c constraints.txt
 
+attrs
 lxml
 bleach
 django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,8 @@ appdirs==1.4.4
     # via fs
 asgiref==3.5.2
     # via django
+attrs==22.1.0
+    # via -r requirements/base.in
 bleach==5.0.1
     # via -r requirements/base.in
 certifi==2022.9.24

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -21,6 +21,8 @@ astroid==2.12.10
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+attrs==22.1.0
+    # via -r requirements/test.txt
 binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
@@ -49,7 +51,6 @@ certifi==2022.9.24
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 chardet==5.0.0
     # via
@@ -189,11 +190,6 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -391,10 +387,6 @@ s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 simplejson==3.17.6
     # via
     #   -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,8 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
+attrs==22.1.0
+    # via -r requirements/base.txt
 bleach==5.0.1
     # via -r requirements/base.txt
 certifi==2022.9.24

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,6 +18,8 @@ astroid==2.12.10
     # via
     #   pylint
     #   pylint-celery
+attrs==22.1.0
+    # via -r requirements/base.txt
 binaryornot==0.4.4
     # via cookiecutter
 bleach==5.0.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,8 @@ astroid==2.12.10
     # via
     #   pylint
     #   pylint-celery
+attrs==22.1.0
+    # via -r requirements/base.txt
 binaryornot==0.4.4
     # via cookiecutter
 bleach==5.0.1
@@ -39,7 +41,6 @@ certifi==2022.9.24
 cffi==1.15.1
     # via
     #   -r requirements/base.txt
-    #   cryptography
     #   pynacl
 chardet==5.0.0
     # via binaryornot
@@ -144,10 +145,6 @@ isort==5.10.1
     # via pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -293,8 +290,6 @@ rich==12.5.1
     # via twine
 s3transfer==0.6.0
     # via boto3
-secretstorage==3.3.3
-    # via keyring
 simplejson==3.17.6
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
### Decouple LTI 1.3 Launch from LtiConsumerXBlock

Purpose
-------

The purpose of these changes is to decouple the LTI 1.3 launch from the LtiConsumerXBlock. It is in accordance with the ADR "0007 Decouple LTI 1.3 Launch from XBlock and edX Platform", which is currently under review. The pull request for the ADR is here: https://github.com/openedx/xblock-lti-consumer/pull/281.

The general premise of these changes is to shift the responsibility of defining key launch claims to users of the library. Such claims include user ID, user role, resource link ID, etc. Prior to this change, this context was defined directly in the launch view by referencing XBlock fields and functions, thereby tying the LTI 1.3 launch to the XBlock. By shifting the responsibility out of the view, we will be able to genericize the launch and make it functional in more contexts than just the XBlock and the XBlock runtime.

In short, the key launch claims are encoded in an instance of a data class Lti1p3LaunchData. Users of the library will instantiate this class with necessary launch data to it and pass the instance to various methods of the Python API to communicate the data to the library. Please see the aforementioned ADR for more details about this decoupling strategy.

Note that the majority of these changes affect only the basic LTI 1.3 launch. There have largely been no changes to LTI 1.3 Advantage Services. The one exception is the Deep Linking content launch endpoint. This is because this launch is implemented in the basic LTI 1.3 launch, and it was necessary to make the same changes to the deep linking content launch to ensure that it works properly. Otherwise, LTI 1.3 Advantage Services are out of scope of these changes. 


Change Summary for Developers
-----------------------------

Below is a summary of changes contained in this pull request.

* added an Lti1p3LaunchData data class
* added caching for Lti1p3LaunchData to limit data sent in request query or form parameters
* modified Python API methods to take Lti1p3LaunchData as a required argument
  * get_lti_1p3_launch_info
  * get_lti_1p3_launch_start_url
  * get_lti_1p3_content_url
* replaced references to LtiConsumerXBlock.location with Lti1p3LaunchData.config_id
* removed definition of key LTI 1.3 claims from the launch_gate_endpoint and instantiated Lti1p3LaunchData from within the LtiConsumerXBlock instead
* added a required launch_data_key request query parameter to the deep_linking_content_endpoint and refactored associated templates and template tags to pass this parameter in the request to the view

Change Summary for Course Staff and Instructors
-----------------------------------------------

The only changes relevant for course staff and instructors is that the access token and keyset URLs displayed in Studio have changed in format.

The old format was:

Access Token URL: `https://courses.edx.org/api/lti_consumer/v1/token/block-v1:edX+999+2022Q3+type@lti_consumer+block@714c10a5e4df452da9d058788acb56be`
Keyset URL: `https://courses.edx.org/api/lti_consumer/v1/public_keysets/block-v1:edX+999+2022Q3+type@lti_consumer+block@714c10a5e4df452da9d058788acb56be`

The new format is:

Access Token URL: `https://courses.edx.org/api/lti_consumer/v1/token/c3f6af60-dbf2-4f85-8974-4ff870068d43`
Keyset URL: `https://courses.edx.org/api/lti_consumer/v1/public_keysets/c3f6af60-dbf2-4f85-8974-4ff870068d43`

The difference is in the slug at the end of the URL. In the old format, the slug was the UsageKey of the XBlock associated with the LTI integration. In the new format, the slug is the config_id of the LtiConfiguration associated with the LTI integration. This is an iterative step toward decoupling the access_token_endpoint and the public_keyset_endpoint views from the XBlock location field. The XBlock location field appears as the usage_key parameter to both views. We cannot simply remove the usage_key parameter from the views, because existing LTI 1.3 integrations may have been created using the old format, and we need to maintain backwards compatibility. This change, however, prevents new integrations from being created that are coupled to the XBlock. In the future, we may address integrations that use the old format to fully decouple the XBlock from the views.


Testing
-------

Unit tests were added for all changes.

In addition, manual testing was performed using the instructions in the documents listed below.

* https://github.com/openedx/xblock-lti-consumer#lti-13
* https://openedx.atlassian.net/wiki/spaces/COMM/pages/1858601008/How+to+run+the+LTI+Validation+test

Resources
---------
JIRA: MST-1603: https://2u-internal.atlassian.net/browse/MST-1603