### PR TITLE
API gets config from launch data via config_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,13 +15,25 @@ Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/release
 
 Unreleased
 ~~~~~~~~~~
+6.0.0 - 2022-10-24
+------------------
+BREAKING CHANGE:
+
+Please note that additional breaking changes will be forthcoming in future versions of this library.
+
+* Modified Python API methods to use config_id (the UUID field) exclusively rather than config.id or block.
+
+  * For the functions changed in 5.0.0 the config_id is available in the launch_data.
+  * Other functions had config.id changed to config_id and block removed as an argument.
+  * The new function config_id_for_block gets that config ID if all you have is a block.
+
 5.0.1 - 2022-10-17
 ------------------
 * Fixed a bug that prevented LTI 1.3 launches from occurring in the browser due to Django's clickjacking protection.
 
   * Added the xframe_options_exempt view decorator to launch_gate_endpoint to allow loading response in an <iframe> tags
 * Fixed a bug in the URL used for an LTI 1.3 launch; the library now sends LTI 1.3 launches to the redirect_uri provided
-  by the Tool in the authentication request, instead of the preregistered target_link_uri. 
+  by the Tool in the authentication request, instead of the preregistered target_link_uri.
 
 5.0.0 - 2022-10-12
 ------------------
@@ -107,7 +119,7 @@ Please note that additional breaking changes will be forthcoming in future versi
 3.4.1 - 2022-02-01
 ------------------
 
-* Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches 
+* Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches
   claim message definition of the field.
   See docs at https://www.imsglobal.org/spec/lti/v1p3#target-link-uri
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '5.0.1'
+__version__ = '6.0.0'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -932,13 +932,13 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         custom_parameters['custom_component_display_name'] = str(self.display_name)
 
-        if self.due:  # pylint: disable=no-member
+        if self.due:
             custom_parameters.update({
-                'custom_component_due_date': self.due.strftime('%Y-%m-%d %H:%M:%S')  # pylint: disable=no-member
+                'custom_component_due_date': self.due.strftime('%Y-%m-%d %H:%M:%S')
             })
-            if self.graceperiod:  # pylint: disable=no-member
+            if self.graceperiod:
                 custom_parameters.update({
-                    'custom_component_graceperiod': str(self.graceperiod.total_seconds())  # pylint: disable=no-member
+                    'custom_component_graceperiod': str(self.graceperiod.total_seconds())
                 })
 
         return custom_parameters
@@ -947,9 +947,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Is it now past this problem's due date, including grace period?
         """
-        due_date = self.due  # pylint: disable=no-member
-        if self.graceperiod is not None and due_date:  # pylint: disable=no-member
-            close_date = due_date + self.graceperiod  # pylint: disable=no-member
+        due_date = self.due
+        if self.graceperiod is not None and due_date:
+            close_date = due_date + self.graceperiod
         else:
             close_date = due_date
         return close_date is not None and timezone.now() > close_date

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -973,9 +973,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Runtime import since this will only run in the
         # Open edX LMS/Studio environments.
         # pylint: disable=import-outside-toplevel
-        from lti_consumer.api import get_lti_consumer
+        from lti_consumer.api import config_id_for_block, get_lti_consumer
 
-        return get_lti_consumer(block=self)
+        return get_lti_consumer(config_id_for_block(self))
 
     def extract_real_user_data(self):
         """
@@ -1034,8 +1034,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         launch_data = self.get_lti_1p3_launch_data()
         context.update(
             get_lti_1p3_launch_info(
-                launch_data=launch_data,
-                block=self
+                launch_data,
             )
         )
 
@@ -1423,8 +1422,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Open edX LMS/Studio environments.
         # TODO: Replace this with a more appropriate API function that is intended for public use.
         # pylint: disable=import-outside-toplevel
-        from lti_consumer.api import _get_lti_config
-        lti_config = _get_lti_config(block=self)
+        from lti_consumer.api import config_id_for_block
+        config_id = config_id_for_block(self)
 
         location = self.location  # pylint: disable=no-member
         course_key = str(location.course_key)
@@ -1432,7 +1431,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         launch_data = Lti1p3LaunchData(
             user_id=self.external_user_id,
             user_role=self.role,
-            config_id=lti_config.config_id,
+            config_id=config_id,
             resource_link_id=str(location),
             launch_presentation_document_target="iframe",
             context_id=course_key,
@@ -1473,7 +1472,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             from lti_consumer.api import get_lti_1p3_content_url  # pylint: disable=import-outside-toplevel
             lti_block_launch_handler = get_lti_1p3_content_url(
                 launch_data,
-                block=self,
             )
 
         return lti_block_launch_handler

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -264,7 +264,7 @@ class LtiConfiguration(models.Model):
         if block is None:
             if self.location is None:
                 raise ValueError(_("Block location not set, it's not possible to retrieve the block."))
-            block = self._block = compat.load_block_as_anonymous_user(self.location)
+            block = self._block = compat.load_block_as_user(self.location)
         return block
 
     @block.setter

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -60,24 +60,6 @@ def get_database_config_waffle_flag():
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_DATABASE_CONFIG}', __name__)
 
 
-def run_xblock_handler(*args, **kwargs):
-    """
-    Import and run `handle_xblock_callback` from LMS
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from lms.djangoapps.courseware.module_render import handle_xblock_callback
-    return handle_xblock_callback(*args, **kwargs)
-
-
-def run_xblock_handler_noauth(*args, **kwargs):
-    """
-    Import and run `handle_xblock_callback_noauth` from LMS
-    """
-    # pylint: disable=import-error,import-outside-toplevel
-    from lms.djangoapps.courseware.module_render import handle_xblock_callback_noauth
-    return handle_xblock_callback_noauth(*args, **kwargs)
-
-
 def load_block_as_user(location):
     """
     Load a block as the current user, or load as the anonymous user if no user is available.

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -60,7 +60,7 @@ def get_database_config_waffle_flag():
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_DATABASE_CONFIG}', __name__)
 
 
-def load_block_as_user(location):
+def load_block_as_user(location):  # pragma: nocover
     """
     Load a block as the current user, or load as the anonymous user if no user is available.
     """
@@ -94,7 +94,7 @@ def load_block_as_user(location):
         return _load_block_as_anonymous_user(location, descriptor)
 
 
-def _load_block_as_anonymous_user(location, descriptor):
+def _load_block_as_anonymous_user(location, descriptor):  # pragma: nocover
     """
     Load a block as the anonymous user because no user is available.
 
@@ -124,7 +124,7 @@ def _load_block_as_anonymous_user(location, descriptor):
         return descriptor
 
 
-def get_user_from_external_user_id(external_user_id):
+def get_user_from_external_user_id(external_user_id):  # pragma: nocover
     """
     Import ExternalId model and find user by external_user_id
     """
@@ -142,7 +142,8 @@ def get_user_from_external_user_id(external_user_id):
         raise LtiError('Invalid userID') from exception
 
 
-def publish_grade(block, user, score, possible, only_if_higher=False, score_deleted=None, comment=None):
+def publish_grade(block, user, score, possible,
+                  only_if_higher=False, score_deleted=None, comment=None):  # pragma: nocover
     """
     Import grades signals and publishes score by triggering SCORE_PUBLISHED signal.
     """
@@ -162,7 +163,7 @@ def publish_grade(block, user, score, possible, only_if_higher=False, score_dele
     )
 
 
-def user_has_access(*args, **kwargs):
+def user_has_access(*args, **kwargs):  # pragma: nocover
     """
     Import and run `has_access` from LMS
     """
@@ -171,7 +172,7 @@ def user_has_access(*args, **kwargs):
     return has_access(*args, **kwargs)
 
 
-def user_has_studio_write_access(*args, **kwargs):
+def user_has_studio_write_access(*args, **kwargs):  # pragma: nocover
     """
     Import and run `has_studio_write_access` from common modules.
 
@@ -183,7 +184,7 @@ def user_has_studio_write_access(*args, **kwargs):
     return has_studio_write_access(*args, **kwargs)
 
 
-def get_course_by_id(course_key):
+def get_course_by_id(course_key):  # pragma: nocover
     """
     Import and run `get_course_by_id` from LMS
 
@@ -200,7 +201,7 @@ def get_course_by_id(course_key):
     return lms_get_course_by_id(course_key)
 
 
-def user_course_access(*args, **kwargs):
+def user_course_access(*args, **kwargs):  # pragma: nocover
     """
     Import and run `check_course_access` from LMS
     """
@@ -209,7 +210,7 @@ def user_course_access(*args, **kwargs):
     return check_course_access(*args, **kwargs)
 
 
-def batch_get_or_create_externalids(users):
+def batch_get_or_create_externalids(users):  # pragma: nocover
     """
     Given a list of user, returns corresponding external id's
 
@@ -224,7 +225,7 @@ def batch_get_or_create_externalids(users):
     return ExternalId.batch_get_or_create_user_ids(users, 'lti')
 
 
-def get_course_members(course_key):
+def get_course_members(course_key):  # pragma: nocover
     """
     Returns a dict containing all users associated with the given course
     """
@@ -251,7 +252,7 @@ def request_cached(func) -> Callable[[Callable], Callable]:
         return func
 
 
-def clean_course_id(model_form: ModelForm) -> CourseKey:
+def clean_course_id(model_form: ModelForm) -> CourseKey:  # pragma: nocover
     """
     Import and run `clean_course_id` from LMS
     """
@@ -260,7 +261,7 @@ def clean_course_id(model_form: ModelForm) -> CourseKey:
     return lms_clean_course_id(model_form)
 
 
-def get_event_tracker():
+def get_event_tracker():  # pragma: nocover
     """
     Import and return LMS event tracking function
     """

--- a/lti_consumer/signals.py
+++ b/lti_consumer/signals.py
@@ -31,7 +31,7 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
             and instance.score_given:
         try:
             # Load block using LMS APIs and check if the block is graded and still accept grades.
-            block = compat.load_block_as_anonymous_user(instance.line_item.resource_link_id)
+            block = compat.load_block_as_user(instance.line_item.resource_link_id)
             if block.has_score and (not block.is_past_due() or block.accept_grades_past_due):
                 # Map external ID to platform user
                 user = compat.get_user_from_external_user_id(instance.user_id)

--- a/lti_consumer/templatetags/get_dl_lti_launch_url.py
+++ b/lti_consumer/templatetags/get_dl_lti_launch_url.py
@@ -20,6 +20,5 @@ def get_dl_lti_launch_url(content_item, launch_data):
     """
     return get_lti_1p3_launch_start_url(
         launch_data,
-        config_id=content_item.lti_configuration.id,
         dl_content_id=content_item.id,
     )

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -144,7 +144,7 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         self.compat.get_external_id_for_user.return_value = "12345"
         model_compat_patcher = patch("lti_consumer.models.compat")
         model_compat = model_compat_patcher.start()
-        model_compat.load_block_as_anonymous_user.return_value = self.xblock
+        model_compat.load_block_as_user.return_value = self.xblock
         self.addCleanup(model_compat_patcher.stop)
 
     def test_invalid_lti_version(self):

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -71,7 +71,7 @@ class LtiAgsLineItemViewSetTestCase(APITransactionTestCase):
         self.addCleanup(compat_mock.stop)
         self._compat_mock = compat_mock.start()
         self._compat_mock.get_user_from_external_user_id.return_value = self._mock_user
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
 
     def _set_lti_token(self, scopes=None):
         """
@@ -431,7 +431,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
             "gradingProgress": grading_progress,
         })
 
-        self._compat_mock.load_block_as_anonymous_user.assert_not_called()
+        self._compat_mock.load_block_as_user.assert_not_called()
         self._compat_mock.get_user_from_external_user_id.assert_not_called()
 
     def test_xblock_grade_publish_on_score_save(self):
@@ -439,7 +439,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         Test that the grade is submitted when gradingProgress is `FullyGraded`.
         """
         # Set up LMS mocks
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
         self._compat_mock.get_user_from_external_user_id.return_value = 'user_mock'
         self.xblock.set_user_module_score = Mock()
 
@@ -452,7 +452,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         # Check if publish grade was called
         self.xblock.set_user_module_score.assert_called_once()
         self._compat_mock.get_user_from_external_user_id.assert_called_once()
-        self._compat_mock.load_block_as_anonymous_user.assert_called_once()
+        self._compat_mock.load_block_as_user.assert_called_once()
 
         call_args = self.xblock.set_user_module_score.call_args.args
         self.assertEqual(call_args, ('user_mock', 0.83, 1, 'This is exceptional work.'))
@@ -462,7 +462,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         Test when given score is bigger than maximum score.
         """
         # Return block bypassing LMS API
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
         self._compat_mock.get_user_from_external_user_id.return_value = 'user_mock'
         self.xblock.set_user_module_score = Mock()
 
@@ -494,7 +494,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.xblock.runtime.publish.side_effect = LmsException
 
         # Return block bypassing LMS API
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
 
         # Check that the except statement catches the exception
         with self.assertRaises(LmsException):
@@ -511,7 +511,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self._post_lti_score()
 
         # Check that the block wasn't set if due date is past
-        self._compat_mock.load_block_as_anonymous_user.assert_called_once()
+        self._compat_mock.load_block_as_user.assert_called_once()
         self._compat_mock.get_user_from_external_user_id.assert_not_called()
         self.xblock.set_user_module_score.assert_not_called()
 
@@ -521,7 +521,7 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         Test grade publish after due date when accept_grades_past_due is True. Grade should publish.
         """
         # Return block bypassing LMS API
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
         self._compat_mock.get_user_from_external_user_id.return_value = 'user_mock'
         self.xblock.set_user_module_score = Mock()
 

--- a/lti_consumer/tests/unit/plugin/test_views_lti_deep_linking.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_deep_linking.py
@@ -80,7 +80,7 @@ class LtiDeepLinkingTestCase(APITransactionTestCase):
         self.addCleanup(compat_mock.stop)
         self._compat_mock = compat_mock.start()
         self._compat_mock.get_user_from_external_user_id.return_value = self._mock_user
-        self._compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        self._compat_mock.load_block_as_user.return_value = self.xblock
 
 
 @ddt.ddt

--- a/lti_consumer/tests/unit/test_api.py
+++ b/lti_consumer/tests/unit/test_api.py
@@ -8,22 +8,25 @@ import ddt
 from Cryptodome.PublicKey import RSA
 from django.test.testcases import TestCase
 from edx_django_utils.cache import get_cache_key
-from opaque_keys.edx.locations import Location
 
 from lti_consumer.api import (
+    _get_config_by_config_id,
     _get_or_create_local_lti_config,
+    config_id_for_block,
     get_lti_1p3_content_url,
     get_deep_linking_data,
     get_lti_1p3_launch_info,
     get_lti_1p3_launch_start_url,
-    get_lti_consumer,
-    validate_lti_1p3_launch_data
+    validate_lti_1p3_launch_data,
 )
 from lti_consumer.data import Lti1p3LaunchData
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration, LtiDlContentItem
 from lti_consumer.tests.test_utils import make_xblock
 from lti_consumer.utils import get_data_from_cache
+
+# it's convenient to have this in lowercase to compare to URLs
+_test_config_id = "6c440bf4-face-beef-face-e8bcfb1e53bd"
 
 
 class Lti1P3TestCase(TestCase):
@@ -34,8 +37,15 @@ class Lti1P3TestCase(TestCase):
         """
         Set up an empty block configuration.
         """
-        self.xblock = None
-        self.lti_config = None
+        self._setup_lti_block()
+
+        # Patch compat method to avoid calls to modulestore
+        patcher = patch(
+            'lti_consumer.plugin.compat.load_block_as_user',
+        )
+        self.addCleanup(patcher.stop)
+        self._load_block_patch = patcher.start()
+        self._load_block_patch.return_value = self.xblock
 
         return super().setUp()
 
@@ -48,7 +58,7 @@ class Lti1P3TestCase(TestCase):
         public_key = rsa_key.publickey().export_key()
 
         xblock_attributes = {
-            'lti_version': 'lti_1p3',
+            'lti_version': LtiConfiguration.LTI_1P3,
             'lti_1p3_launch_url': 'http://tool.example/launch',
             'lti_1p3_oidc_url': 'http://tool.example/oidc',
             # We need to set the values below because they are not automatically
@@ -60,17 +70,60 @@ class Lti1P3TestCase(TestCase):
 
         # Create lti configuration
         self.lti_config = LtiConfiguration.objects.create(
-            location=self.xblock.location  # pylint: disable=no-member
+            config_id=_test_config_id,
+            location=self.xblock.location,  # pylint: disable=no-member
+            block=self.xblock,
+            version=LtiConfiguration.LTI_1P3,
+            config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
         )
 
-    @staticmethod
-    def _get_lti_1p3_launch_data():
+    def _get_lti_1p3_launch_data(self):
         return Lti1p3LaunchData(
             user_id="1",
             user_role="student",
-            config_id="1",
+            config_id=self.lti_config.config_id,
             resource_link_id="resource_link_id",
         )
+
+
+@ddt.ddt
+class TestConfigIdForBlock(TestCase):
+    """
+    Test config ID for block which is either a simple lookup
+    or creates the config if it hasn't existed before. Config
+    creation forks on store type.
+    """
+    def setUp(self):
+        xblock_attributes = {
+            'lti_version': LtiConfiguration.LTI_1P1,
+        }
+        self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, xblock_attributes)
+
+    def test_double_fetch(self):
+        self.xblock.config_type = 'database'
+        config_id = config_id_for_block(self.xblock)
+        self.assertIsNotNone(config_id)
+        config = _get_config_by_config_id(config_id)
+        self.assertEqual(LtiConfiguration.CONFIG_ON_DB, config.config_store)
+
+        # fetch again, shouldn't make a new one
+        second_config_id = config_id_for_block(self.xblock)
+        self.assertEqual(config_id, second_config_id)
+
+    @ddt.data(
+        ('external', LtiConfiguration.CONFIG_EXTERNAL),
+        ('database', LtiConfiguration.CONFIG_ON_DB),
+        ('any other val', LtiConfiguration.CONFIG_ON_XBLOCK),
+    )
+    @patch('lti_consumer.api.get_external_config_from_filter')
+    def test_store_types(self, mapping_pair, mock_external_config):
+        mock_external_config.return_value = {"version": LtiConfiguration.LTI_1P3}
+        str_store, result_store = mapping_pair
+        self.xblock.config_type = str_store
+        config_id = config_id_for_block(self.xblock)
+        self.assertIsNotNone(config_id)
+        config = _get_config_by_config_id(config_id)
+        self.assertEqual(result_store, config.config_store)
 
 
 @ddt.ddt
@@ -184,63 +237,6 @@ class TestGetOrCreateLocalLtiConfiguration(TestCase):
         self.assertEqual(lti_config.external_id, None)
 
 
-class TestGetLtiConsumer(TestCase):
-    """
-    Unit tests for get_lti_consumer API method.
-    """
-    def test_retrieve_with_block(self):
-        """
-        Check if the API creates a model if no object matching properties is found.
-        """
-        block = Mock()
-        block.location = 'block-v1:course+test+2020+type@problem+block@test'
-        block.lti_version = LtiConfiguration.LTI_1P3
-        LtiConfiguration.objects.create(location=block.location)
-
-        # Call API
-        with patch("lti_consumer.models.LtiConfiguration.get_lti_consumer") as mock_get_lti_consumer:
-            get_lti_consumer(block=block)
-            mock_get_lti_consumer.assert_called_once()
-
-        # Check that there's just a single LTI Config in the models
-        self.assertEqual(LtiConfiguration.objects.all().count(), 1)
-
-    def test_retrieve_with_id(self):
-        """
-        Check if the API retrieves a model if the configuration matches.
-        """
-        location = 'block-v1:course+test+2020+type@problem+block@test'
-        lti_config = LtiConfiguration.objects.create(location=location)
-
-        # Call API
-        with patch("lti_consumer.models.LtiConfiguration.get_lti_consumer") as mock_get_lti_consumer:
-            get_lti_consumer(config_id=lti_config.id)
-            mock_get_lti_consumer.assert_called_once()
-
-    def test_retrieve_from_external_configuration(self):
-        """
-        Check if the API creates a model from the external configuration ID
-        """
-        external_id = 'my-plugin:my-lti-tool'
-
-        block = Mock()
-        block.config_type = 'external'
-        block.location = Location('edx', 'Demo_Course', '2020', 'T2', 'UNIV')
-        block.external_config = external_id
-        block.lti_version = LtiConfiguration.LTI_1P1
-
-        # Call API
-        with patch("lti_consumer.models.LtiConfiguration.get_lti_consumer") as mock_get_lti_consumer, \
-                patch("lti_consumer.api.get_external_config_from_filter") as mock_get_from_filter:
-            mock_get_from_filter.return_value = {"version": "lti_1p1"}
-            get_lti_consumer(block=block)
-            mock_get_lti_consumer.assert_called_once()
-            mock_get_from_filter.assert_called_once_with({"course_key": block.location.course_key}, external_id)
-
-        # Check that there's just a single LTI Config in the models
-        self.assertEqual(LtiConfiguration.objects.all().count(), 1)
-
-
 class TestValidateLti1p3LaunchData(TestCase):
     """
     Unit tests for validate_lti_1p3_launch_data API method.
@@ -273,7 +269,7 @@ class TestValidateLti1p3LaunchData(TestCase):
         launch_data = Lti1p3LaunchData(
             user_id="1",
             user_role="student",
-            config_id="1",
+            config_id=_test_config_id,
             resource_link_id="resource_link_id",
             context_id="1",
             context_type=["course_offering"],
@@ -292,7 +288,7 @@ class TestValidateLti1p3LaunchData(TestCase):
         launch_data = Lti1p3LaunchData(
             user_id="1",
             user_role="student",
-            config_id="1",
+            config_id=_test_config_id,
             resource_link_id="resource_link_id",
         )
 
@@ -319,7 +315,7 @@ class TestValidateLti1p3LaunchData(TestCase):
         launch_data = Lti1p3LaunchData(
             user_id="1",
             user_role=user_role,
-            config_id="1",
+            config_id=_test_config_id,
             resource_link_id="resource_link_id",
         )
 
@@ -341,7 +337,7 @@ class TestValidateLti1p3LaunchData(TestCase):
         launch_data = Lti1p3LaunchData(
             user_id="1",
             user_role="student",
-            config_id="1",
+            config_id=_test_config_id,
             resource_link_id="resource_link_id",
             context_id="1",
             context_type=context_type,
@@ -378,28 +374,24 @@ class TestGetLti1p3LaunchInfo(TestCase):
         return Lti1p3LaunchData(
             user_id="1",
             user_role="student",
-            config_id="1",
+            config_id=_test_config_id,
             resource_link_id="resource_link_id",
         )
-
-    def test_no_parameters(self):
-        """
-        Check if the API creates a model if no object matching properties is found.
-        """
-        with self.assertRaises(Exception):
-            get_lti_1p3_launch_info({})
 
     def test_retrieve_with_id(self):
         """
         Check if the API retrieves the launch with id.
         """
         location = 'block-v1:course+test+2020+type@problem+block@test'
-        lti_config = LtiConfiguration.objects.create(location=location)
+        lti_config = LtiConfiguration.objects.create(
+            location=location,
+            config_id=_test_config_id,
+        )
 
         launch_data = self._get_lti_1p3_launch_data()
 
         # Call and check returns
-        launch_info = get_lti_1p3_launch_info(launch_data, config_id=lti_config.id)
+        launch_info = get_lti_1p3_launch_info(launch_data)
 
         # Not checking all data here, there's a test specific for that
         self.assertEqual(launch_info['client_id'], lti_config.lti_1p3_client_id)
@@ -415,7 +407,10 @@ class TestGetLti1p3LaunchInfo(TestCase):
         launch_data = self._get_lti_1p3_launch_data()
 
         # Create LTI Config and Deep linking object
-        lti_config = LtiConfiguration.objects.create(location=block.location)
+        lti_config = LtiConfiguration.objects.create(
+            location=block.location,
+            config_id=_test_config_id,
+        )
         LtiDlContentItem.objects.create(
             lti_configuration=lti_config,
             content_type=LtiDlContentItem.IMAGE,
@@ -423,7 +418,7 @@ class TestGetLti1p3LaunchInfo(TestCase):
         )
 
         # Call API
-        launch_info = get_lti_1p3_launch_info(launch_data, block=block)
+        launch_info = get_lti_1p3_launch_info(launch_data)
 
         # Retrieve created config and check full launch info data
         lti_config = LtiConfiguration.objects.get()
@@ -451,7 +446,10 @@ class TestGetLti1p3LaunchInfo(TestCase):
         Check if the API can return launch info for LtiConfiguration objects without
         specified block location.
         """
-        lti_config = LtiConfiguration.objects.create(version=LtiConfiguration.LTI_1P3)
+        lti_config = LtiConfiguration.objects.create(
+            version=LtiConfiguration.LTI_1P3,
+            config_id=_test_config_id,
+        )
         LtiDlContentItem.objects.create(
             lti_configuration=lti_config,
             content_type=LtiDlContentItem.IMAGE,
@@ -460,7 +458,7 @@ class TestGetLti1p3LaunchInfo(TestCase):
 
         launch_data = self._get_lti_1p3_launch_data()
 
-        launch_info = get_lti_1p3_launch_info(launch_data, config_id=lti_config.id)
+        launch_info = get_lti_1p3_launch_info(launch_data)
         self.assertEqual(
             launch_info,
             {
@@ -483,25 +481,17 @@ class TestGetLti1p3LaunchInfo(TestCase):
 
 class TestGetLti1p3LaunchUrl(Lti1P3TestCase):
     """
-    Unit tests for get_lti_1p3_launch_start_url API method.
+    Unit tests for LTI 1.3 launch API methods.
     """
-    def test_no_parameters(self):
-        """
-        Check if the API creates a model if no object matching properties is found.
-        """
-        with self.assertRaises(Exception):
-            get_lti_1p3_launch_start_url({})
-
     def test_get_normal_lti_launch_url(self):
         """
         Check if the correct launch url is retrieved for a normal LTI 1.3 launch.
         """
-        self._setup_lti_block()
 
         launch_data = self._get_lti_1p3_launch_data()
 
         # Call API for normal LTI launch initiation.
-        launch_url = get_lti_1p3_launch_start_url(launch_data, block=self.xblock)
+        launch_url = get_lti_1p3_launch_start_url(launch_data)
 
         parameters = parse_qs(urlparse(launch_url).query)
         launch_data = get_data_from_cache(parameters.get("lti_message_hint")[0])
@@ -513,15 +503,11 @@ class TestGetLti1p3LaunchUrl(Lti1P3TestCase):
         """
         Check if the correct launch url is retrieved for a deep linking LTI 1.3 launch.
         """
-        self._setup_lti_block()
 
         launch_data = self._get_lti_1p3_launch_data()
 
         # Call API for normal LTI launch initiation.
-        launch_url = get_lti_1p3_launch_start_url(launch_data, block=self.xblock)
-
-        parameters = parse_qs(urlparse(launch_url).query)
-        launch_url = get_lti_1p3_launch_start_url(launch_data, block=self.xblock, deep_link_launch=True)
+        launch_url = get_lti_1p3_launch_start_url(launch_data, deep_link_launch=True)
 
         parameters = parse_qs(urlparse(launch_url).query)
         launch_data = get_data_from_cache(parameters.get("lti_message_hint")[0])
@@ -533,15 +519,14 @@ class TestGetLti1p3LaunchUrl(Lti1P3TestCase):
         """
         Check if the correct launch url is retrieved for a deep linking content item LTI 1.3 launch.
         """
-        self._setup_lti_block()
 
         launch_data = self._get_lti_1p3_launch_data()
 
         # Call API for normal LTI launch initiation.
-        launch_url = get_lti_1p3_launch_start_url(launch_data, block=self.xblock)
+        launch_url = get_lti_1p3_launch_start_url(launch_data)
 
         parameters = parse_qs(urlparse(launch_url).query)
-        launch_url = get_lti_1p3_launch_start_url(launch_data, block=self.xblock, dl_content_id="1")
+        launch_url = get_lti_1p3_launch_start_url(launch_data, dl_content_id="1")
 
         parameters = parse_qs(urlparse(launch_url).query)
         launch_data = get_data_from_cache(parameters.get("lti_message_hint")[0])
@@ -559,18 +544,17 @@ class TestGetLti1p3ContentUrl(Lti1P3TestCase):
         """
         Check if the correct LTI content presentation is returned on a normal LTI Launch.
         """
+
         launch_data = self._get_lti_1p3_launch_data()
 
         mock_get_launch_url.return_value = 'test_url'
-        self._setup_lti_block()
-        self.assertEqual(get_lti_1p3_content_url(launch_data, block=self.xblock), 'test_url')
+        self.assertEqual(get_lti_1p3_content_url(launch_data), 'test_url')
 
     def test_lti_content_presentation_single_link(self):
         """
         Check if the correct LTI content presentation is returned if a `ltiResourceLink`
         content type is present.
         """
-        self._setup_lti_block()
 
         launch_data = self._get_lti_1p3_launch_data()
 
@@ -582,7 +566,7 @@ class TestGetLti1p3ContentUrl(Lti1P3TestCase):
         )
 
         # Call API to retrieve content item URL
-        launch_url = get_lti_1p3_content_url(launch_data, block=self.xblock)
+        launch_url = get_lti_1p3_content_url(launch_data)
 
         parameters = parse_qs(urlparse(launch_url).query)
         launch_data = get_data_from_cache(parameters.get("lti_message_hint")[0])
@@ -595,7 +579,6 @@ class TestGetLti1p3ContentUrl(Lti1P3TestCase):
         Check if the correct LTI content presentation is returned if multiple LTI DL
         content items are set up.
         """
-        self._setup_lti_block()
 
         launch_data = self._get_lti_1p3_launch_data()
 
@@ -618,7 +601,7 @@ class TestGetLti1p3ContentUrl(Lti1P3TestCase):
         self.assertIn(
             # Checking for the content presentation URL
             f"/api/lti_consumer/v1/lti/{self.lti_config.id}/lti-dl/content?launch_data_key={launch_data_key}",
-            get_lti_1p3_content_url(launch_data, block=self.xblock),
+            get_lti_1p3_content_url(launch_data),
         )
 
 
@@ -646,10 +629,7 @@ class TestGetLtiDlContentItemData(TestCase):
             attributes={"test": "test"},
         )
 
-        data = get_deep_linking_data(
-            deep_linking_id=content_item.id,
-            config_id=self.lti_config.id,
-        )
+        data = get_deep_linking_data(content_item.id, self.lti_config.config_id)
 
         self.assertEqual(
             data,
@@ -668,7 +648,4 @@ class TestGetLtiDlContentItemData(TestCase):
         )
 
         with self.assertRaises(Exception):
-            get_deep_linking_data(
-                deep_linking_id=content_item.id,
-                config_id=self.lti_config.id,
-            )
+            get_deep_linking_data(content_item.id, self.lti_config.config_id)

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1576,7 +1576,7 @@ class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
 
         patcher = patch(
             'lti_consumer.models.compat',
-            **{'load_block_as_anonymous_user.return_value': self.xblock}
+            **{'load_block_as_user.return_value': self.xblock}
         )
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -1751,7 +1751,7 @@ class TestLti1p3AccessTokenJWK(TestCase):
         self.request = make_jwt_request(jwt)
         patcher = patch(
             'lti_consumer.models.compat',
-            **{'load_block_as_anonymous_user.return_value': self.xblock}
+            **{'load_block_as_user.return_value': self.xblock}
         )
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -18,7 +18,7 @@ from jwkest.jwk import RSAKey, KEYS
 
 from lti_consumer.exceptions import LtiError
 
-from lti_consumer.api import _get_lti_config
+from lti_consumer.api import config_id_for_block
 from lti_consumer.data import Lti1p3LaunchData
 from lti_consumer.lti_xblock import LtiConsumerXBlock, parse_handler_suffix, valid_config_type_values
 from lti_consumer.lti_1p3.tests.utils import create_jwt
@@ -598,7 +598,7 @@ class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
         self.xblock.lti_id = provider
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{provider}:{key}:{secret}"])
 
-        with patch('lti_consumer.models.LtiConfiguration.block', return_value=self.xblock):
+        with patch('lti_consumer.plugin.compat.load_block_as_user', return_value=self.xblock):
             self.xblock._get_lti_consumer()  # pylint: disable=protected-access
 
         mock_lti_consumer.assert_called_with(self.xblock.launch_url, key, secret)
@@ -1483,13 +1483,11 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         launch_data = self.xblock.get_lti_1p3_launch_data()
 
-        lti_config = _get_lti_config(block=self.xblock)
-
         course_key = str(self.xblock.location.course_key)  # pylint: disable=no-member
         expected_launch_data = Lti1p3LaunchData(
             user_id="external_user_id",
             user_role="instructor",
-            config_id=lti_config.config_id,
+            config_id=config_id_for_block(self.xblock),
             resource_link_id=str(self.xblock.location),  # pylint: disable=no-member
             launch_presentation_document_target="iframe",
             message_type="LtiResourceLinkRequest",

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -318,7 +318,7 @@ class TestLtiConfigurationModel(TestCase):
         """
         Check if a block is properly loaded when calling the `block` property.
         """
-        compat_mock.load_block_as_anonymous_user.return_value = self.xblock
+        compat_mock.load_block_as_user.return_value = self.xblock
 
         block = self.lti_1p3_config.block
         self.assertEqual(block, self.xblock)
@@ -435,7 +435,7 @@ class TestLtiAgsScoreModel(TestCase):
         compat_mock = patch("lti_consumer.signals.compat")
         self.addCleanup(compat_mock.stop)
         self._compat_mock = compat_mock.start()
-        self._compat_mock.load_block_as_anonymous_user.return_value = make_xblock(
+        self._compat_mock.load_block_as_user.return_value = make_xblock(
             'lti_consumer', LtiConsumerXBlock, {
                 'due': datetime.now(timezone.utc),
                 'graceperiod': timedelta(days=2),


### PR DESCRIPTION
Includes an improvement to anonymous loading because we're going to be using block load all the time for configs stored on the xblock. Basically if the block has already been loaded and bound to a user be happy and leave it. And if the block needs to be loaded and you have a user, load as that user. Only fall through to anonymous user when you have no other option (for example when being called by the LTI provider directly which is not a user).

There are a few cleanup diffs, the only interesting one is that codecov complained about compat so I added pragmas to document our lack of compat tests. The amount of mocking required would make those basically worthless.
