### PR TITLE
fix: remove general use of load_block_as_user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/release
 
 Unreleased
 ~~~~~~~~~~
+6.1.0 - 2022-11-08
+------------------
+* 6.0.0 broke studio functionality because it leaned more heavily on the xblock load which only worked in the LMS.
+
+  * Fix by greatly limiting when we attempt a full xblock load and bind
+
+
+
 6.0.0 - 2022-10-24
 ------------------
 BREAKING CHANGE:

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '6.0.0'
+__version__ = '6.1.0'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -83,11 +83,6 @@ def _get_lti_config_for_block(block):
             block.location,
             LtiConfiguration.CONFIG_ON_XBLOCK,
         )
-
-    # Since the block was passed, preload it to avoid
-    # having to instance the modulestore and fetch it again.
-    lti_config.block = block
-
     return lti_config
 
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -60,18 +60,30 @@ def get_database_config_waffle_flag():
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_DATABASE_CONFIG}', __name__)
 
 
+def load_enough_xblock(location):  # pragma: nocover
+    """
+    Load enough of an xblock to read from for LTI values stored on the block.
+    The block may or may not be bound to the user for actual use depending on
+    what has happened in the request so far.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    # Retrieve descriptor from modulestore
+    return modulestore().get_item(location)
+
+
 def load_block_as_user(location):  # pragma: nocover
     """
     Load a block as the current user, or load as the anonymous user if no user is available.
     """
     # pylint: disable=import-error,import-outside-toplevel
     from crum import get_current_user, get_current_request
-    from xmodule.modulestore.django import modulestore
     from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
     from openedx.core.lib.xblock_utils import request_token
 
     # Retrieve descriptor from modulestore
-    descriptor = modulestore().get_item(location)
+    descriptor = load_enough_xblock(location)
     user = get_current_user()
     request = get_current_request()
     if user and request:

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -480,7 +480,8 @@ def deep_linking_content_endpoint(request, lti_config_id):
         raise Http404 from exc
 
     # check if user has proper access
-    if not has_block_access(request.user, lti_config.block, lti_config.location.course_key):
+    block = compat.load_block_as_user(lti_config.location)
+    if not has_block_access(request.user, block, lti_config.location.course_key):
         log.warning(
             "Permission on LTI Config %r denied for user %r.",
             lti_config_id,
@@ -499,7 +500,7 @@ def deep_linking_content_endpoint(request, lti_config_id):
     # Render LTI-DL contents
     return render(request, 'html/lti-dl/render_dl_content.html', {
         'content_items': content_items,
-        'block': lti_config.block,
+        'block': block,
         'launch_data': launch_data,
     })
 

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -133,19 +133,21 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         )
         self.launch_data_key = cache_lti_1p3_launch_data(self.launch_data)
 
-        self.compat_patcher = patch("lti_consumer.plugin.views.compat")
-        self.compat = self.compat_patcher.start()
-        self.addCleanup(self.compat.stop)
+        compat_patcher = patch("lti_consumer.plugin.views.compat")
+        self.addCleanup(compat_patcher.stop)
+        self.compat = compat_patcher.start()
         course = Mock(name="course")
         course.display_name_with_default = "course_display_name"
         course.display_org_with_default = "course_display_org"
         self.compat.get_course_by_id.return_value = course
         self.compat.get_user_role.return_value = "student"
         self.compat.get_external_id_for_user.return_value = "12345"
+
         model_compat_patcher = patch("lti_consumer.models.compat")
-        model_compat = model_compat_patcher.start()
-        model_compat.load_block_as_user.return_value = self.xblock
         self.addCleanup(model_compat_patcher.stop)
+        model_compat = model_compat_patcher.start()
+        model_compat.load_enough_xblock.return_value = self.xblock
+        model_compat.load_block_as_user.return_value = self.xblock
 
     def test_invalid_lti_version(self):
         """

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -3,7 +3,7 @@ Tests for LTI Advantage Assignments and Grades Service views.
 """
 import json
 from datetime import timedelta
-from unittest.mock import patch, PropertyMock, Mock
+from unittest.mock import patch, Mock
 
 from Cryptodome.PublicKey import RSA
 import ddt
@@ -54,17 +54,14 @@ class LtiAgsLineItemViewSetTestCase(APITransactionTestCase):
             location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
         )
-        # Preload XBlock to avoid calls to modulestore
-        self.lti_config.block = self.xblock
 
         # Patch internal method to avoid calls to modulestore
         patcher = patch(
-            'lti_consumer.models.LtiConfiguration.block',
-            new_callable=PropertyMock,
-            return_value=self.xblock
+            'lti_consumer.plugin.compat.load_enough_xblock',
         )
         self.addCleanup(patcher.stop)
-        self._lti_block_patch = patcher.start()
+        self._load_block_patch = patcher.start()
+        self._load_block_patch.return_value = self.xblock
 
         self._mock_user = Mock()
         compat_mock = patch("lti_consumer.signals.compat")

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -1,7 +1,7 @@
 """
 Tests for LTI Names and Role Provisioning Service views.
 """
-from unittest.mock import Mock, patch, PropertyMock
+from unittest.mock import Mock, patch
 from Cryptodome.PublicKey import RSA
 from jwkest.jwk import RSAKey
 from rest_framework.test import APITransactionTestCase
@@ -140,17 +140,14 @@ class LtiNrpsTestCase(APITransactionTestCase):
             location=self.xblock.location,  # pylint: disable=no-member
             version=LtiConfiguration.LTI_1P3,
         )
-        # Preload XBlock to avoid calls to modulestore
-        self.lti_config.block = self.xblock
 
         # Patch internal method to avoid calls to modulestore
         patcher = patch(
-            'lti_consumer.models.LtiConfiguration.block',
-            new_callable=PropertyMock,
-            return_value=self.xblock
+            'lti_consumer.plugin.compat.load_enough_xblock',
         )
         self.addCleanup(patcher.stop)
-        self._lti_block_patch = patcher.start()
+        self._load_block_patch = patcher.start()
+        self._load_block_patch.return_value = self.xblock
 
         self.context_membership_endpoint = reverse(
             'lti_consumer:lti-nrps-memberships-view-list',

--- a/lti_consumer/tests/unit/test_api.py
+++ b/lti_consumer/tests/unit/test_api.py
@@ -41,7 +41,7 @@ class Lti1P3TestCase(TestCase):
 
         # Patch compat method to avoid calls to modulestore
         patcher = patch(
-            'lti_consumer.plugin.compat.load_block_as_user',
+            'lti_consumer.plugin.compat.load_enough_xblock',
         )
         self.addCleanup(patcher.stop)
         self._load_block_patch = patcher.start()
@@ -72,7 +72,6 @@ class Lti1P3TestCase(TestCase):
         self.lti_config = LtiConfiguration.objects.create(
             config_id=_test_config_id,
             location=self.xblock.location,  # pylint: disable=no-member
-            block=self.xblock,
             version=LtiConfiguration.LTI_1P3,
             config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
         )


### PR DESCRIPTION
For the config model we do not need to go as far as binding the block to the user and already get enough data out of the modulestore to satisfy the storage on the xblock case. Add a new function to get that much xblock only.

For the limited cases where we are using the block more directly as a block we maintain the old function.

Also includes a fix to test_views that was closing the wrong level mock and leaving an open patch into other tests.

The behavior we are fixing is described in https://2u-internal.atlassian.net/browse/MST-1697 - basically, the weird compat.load_block_as_user squirrels its way into LMS specific block loading and binding code and that does not work in Studio. Before version 6, we got away with it because we mostly asked for the config by saying i_can_has_config(block) with a preloaded block and that would be set into the config so you would never try to load it. Version 6 made the only way to get the config i_can_has_config(config_id) which works fine but then config.block triggers the offending code.

Rather than fix config.block as we try to move away from being tightly tied to the block, replace it with a less complete load for the config-on-DB data store case and greatly limit the use of the fancier version.
