### PR TITLE
build: update library version to 6.2.0 to release changes in pull #297

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'


### PR DESCRIPTION
I forgot to update the version number in the `__init__.py` in #297 during a rebase, which is preventing me from releasing the changes. This corrects the version number.