### PR TITLE
build: update library version to 6.3.0 to release changes in pull #297

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/release
 Unreleased
 ~~~~~~~~~~
 
-6.2.0 - 2022-11-16
+6.3.0 - 2022-11-16
 ------------------
 * Adds support for LTI 1.3 Proctoring Service specification in-browser proctoring launch.
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '6.2.0'
+__version__ = '6.3.0'


### PR DESCRIPTION
I made a mistake and published a release and created a tag for a `6.2.0` release without updating the library version in `__init__.py`. After correcting the version number, I couldn't publish a corrected release to PyPI because the `6.2.0` tag was associated with the commit before the commit with the updated version number. Instead of mucking around with pushing modified tags, I'm going to skip to the `6.3.0` tag instead.