### PR TITLE
Add course flag to send external_user_id as user_id in LTI 1.1 XBlock launches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,13 @@ Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/release
 
 Unreleased
 ~~~~~~~~~~
+6.4.0 - 2022-11-18
+------------------
+Adds support for sending an external_user_id in LTI 1.1 XBlock launches. When the
+lti_consumer.enable_external_user_id_1p1_launches CourseWaffleFlag is enabled, the LTI 1.1 launch will send an
+external_user_id as the user_id attribute of the launch. When the lti_consumer.enable_external_user_id_1p1_launches
+CourseWaffleFlag is disabled, the LTI 1.1 launch will continue to send the anonymous_user_id. The external_user_id is
+defined, created, and stored by the external_user_ids Djangoapp in edx-platform.
 
 6.3.0 - 2022-11-16
 ------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '6.3.0'
+__version__ = '6.4.0'

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -31,6 +31,17 @@ WAFFLE_NAMESPACE = 'lti_consumer'
 # .. toggle_warning: None.
 ENABLE_EXTERNAL_CONFIG_FILTER = 'enable_external_config_filter'
 
+# .. toggle_name: lti_consumer.enable_external_user_id_1p1_launches
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables sending a user's external user ID, as created and stored by the external_user_ids
+#    Djangoapp, instead of an anonymous user ID in LTI 1.1 launches.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-11-18
+# .. toggle_tickets: https://github.com/openedx/xblock-lti-consumer/pull/307
+# .. toggle_warning: None.
+ENABLE_EXTERNAL_USER_ID_1P1_LAUNCHES = 'enable_external_user_id_1p1_launches'
+
 # Waffle Flags
 # .. toggle_name: lti_consumer.enable_database_config
 # .. toggle_implementation: CourseWaffleFlag
@@ -52,6 +63,15 @@ def get_external_config_waffle_flag():
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_CONFIG_FILTER}', __name__)
+
+
+def get_external_user_id_1p1_launches_waffle_flag():
+    """
+    Import and return Waffle flag for enabling sending external user IDs in LTI 1.1 launches.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_USER_ID_1P1_LAUNCHES}', __name__)
 
 
 def get_database_config_waffle_flag():

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -8,7 +8,11 @@ from urllib.parse import urlencode
 from django.conf import settings
 from edx_django_utils.cache import get_cache_key, TieredCache
 
-from lti_consumer.plugin.compat import get_external_config_waffle_flag, get_database_config_waffle_flag
+from lti_consumer.plugin.compat import (
+    get_external_config_waffle_flag,
+    get_external_user_id_1p1_launches_waffle_flag,
+    get_database_config_waffle_flag,
+)
 from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredClaim
 
@@ -185,6 +189,17 @@ def external_config_filter_enabled(course_key):
         course_key (opaque_keys.edx.locator.CourseLocator): Course Key
     """
     return get_external_config_waffle_flag().is_enabled(course_key)
+
+
+def external_user_id_1p1_launches_enabled(course_key):
+    """
+    Returns whether the lti_consumer.enable_external_user_id_1p1_launches CourseWaffleFlag is enabled.
+    Returns True if sending external user IDs in LTI 1.1 launches is enabled for the course via the CourseWaffleFlag.
+
+    Arguments:
+        course_key (opaque_keys.edx.locator.CourseLocator): Course Key
+    """
+    return get_external_user_id_1p1_launches_waffle_flag().is_enabled(course_key)
 
 
 def database_config_enabled(course_key):


### PR DESCRIPTION
### Description:

JIRA: [MST-1717](https://2u-internal.atlassian.net/browse/MST-1717)

This commit introduces a new `CourseWaffleFlag` `lti_consumer.enable_external_user_id_1p1_launches`. When this flag is enabled for a course, LTI 1.1 XBlock launches in that course will send the user's `external_user_id` as the `user_id` attribute of the launch. `external_user_id` is the user's external user ID as defined, created, and stored by the `external_user_ids` Djangoapp in the edx-platform. When this waffle is not enabled for a course - the default case - LTI 1.1 XBlock launches in that course will continue to send the user's `anonymous_user_id` as the `user_id` attribute of the launch, as before.

This provides an opt-in opportunity for courses to send a consistent, static, and opaque user identifier in an LTI 1.1 XBlock launch. This may be necessary for integration with LTI tools that require such an identifier.

Please be aware that toggling this flag in a running course carries the risk of breaking the LTI integrations in the course. This flag should also only be enabled for new courses in which no LTI attempts have been made.

### Verification:

This change was manually tested using the testing instructions in the README via an integration with the saLTIre testing tool. Please see the screenshots below. They show two courses to demonstrate that, after the change, the `user_id` is the same.

**Before Change, Course 1:**

<img width="2104" alt="before-course-1" src="https://user-images.githubusercontent.com/11871801/202802848-96d67845-c55d-45ae-9caa-eb193ba29991.png">


**Before Change, Course 2:**

<img width="2017" alt="before-course-2" src="https://user-images.githubusercontent.com/11871801/202802863-44af3233-96c2-4c3e-bb4f-be94301cc32f.png">


**After Change, Course 1:**

<img width="1998" alt="after-course-1" src="https://user-images.githubusercontent.com/11871801/202802885-ce71c204-4daa-4bac-98c2-8e3f8f1aeff1.png">


**After Change, Course 2:**

<img width="2034" alt="after-course-2" src="https://user-images.githubusercontent.com/11871801/202802902-cfc2dbd8-c5bd-48c3-8e75-cd494b175afc.png">


### Testing:

In order to test these changes, follow these steps.

1. Set up an LTI 1.1 integration in Studio by following the steps in the README: https://github.com/openedx/xblock-lti-consumer#lti-11.
2. In the Django admin, add a `CourseWaffleFlag` in `django-waffle > Flags`.
	Name: `lti_consumer.enable_external_user_id_1p1_launches`
	Leave the remaining fields as the default.
3. In the Django admin, add a `CourseWaffleFlag override` in `Waffle_Utils › Waffle flag course overrides`.
	Waffle flag: `lti_consumer.enable_external_user_id_1p1_launches`
	Course id: <course_id of the course you are testing in>
	Override choice: Force On
	Enabled: <check this box>
4. As a non-superuser, load the LTI component in the LMS and observe the `user_id` attribute in the `Message Parameters` section.