### PR TITLE
fix: do not attempt to load the block just to look at the location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+=======
+7.0.1 - 2022-11-29
+------------------
+
+Fix LtiConfiguration clean method to look only at location so that it can work in environments that cannot load the block.
+
 7.0.0 - 2022-11-29
 ------------------
 * Refactor anonymous user to real user rebinding function to use `rebind_user` service.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.0.0'
+__version__ = '7.0.1'

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -240,8 +240,7 @@ class LtiConfiguration(models.Model):
                 "config_store": _("LTI Configuration stores on XBlock needs a block location set."),
             })
         if self.version == self.LTI_1P3 and self.config_store == self.CONFIG_ON_DB:
-            block = compat.load_enough_xblock(self.location)
-            if not database_config_enabled(block.scope_ids.usage_id.context_key):
+            if not database_config_enabled(self.location.course_key):
                 raise ValidationError({
                     "config_store": _("LTI Configuration stores on database is not enabled."),
                 })


### PR DESCRIPTION
The block is not loadable in exams so clean fails in that IDA, but we shouldn't need the block to ask a question about the course.

Validated locally by editing configs in admin and observing that it knows the course ID from the location and uses it to look up the waffle flag.