### PR TITLE
Fix LTI 1.1 Basic Outcomes Service and LTI 2.0 Result Service to Support External User IDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,16 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
-=======
+7.0.2 - 2022-11-29
+------------------
+* Fix the LTI 1.1 Outcome Results Service to be able to tie an outcome pass back to a user when the user ID is an
+  `external_user_id`.
+* Fix the LTI 2.0 Result Service to be able to tie a result pass back to a user when the user ID is an
+  `external_user_id`.
+* Update the `RESULT_SERVICE_SUFFIX_PARSER` regex string to be able to parse UUIDs to accommodate `external_user_ids`.
+* Add a `get_lti_1p1_user_from_user_id` method to the `LtiConsumerXBlock` to get the user object associated with a user
+  ID.
+
 7.0.1 - 2022-11-29
 ------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.0.1'
+__version__ = '7.0.2'

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -183,8 +183,9 @@ class OutcomeService:
             log.debug("[LTI]: %s", error_message)
             return response_xml_template.format(**failure_values)
 
-        anon_id = unquote(sourced_id.split(':')[-1])
-        real_user = self.xblock.runtime.service(self, 'user').get_user_by_anonymous_id(anon_id)
+        user_id = unquote(sourced_id.split(':')[-1])
+        real_user = self.xblock.get_lti_1p1_user_from_user_id(user_id)
+
         if not real_user:  # that means we can't save to database, as we do not have real user id.
             failure_values['imsx_messageIdentifier'] = escape(imsx_message_identifier)
             failure_values['imsx_description'] = "User not found."

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -5,13 +5,14 @@ Unit tests for lti_consumer.outcomes module
 import textwrap
 import unittest
 from copy import copy
-
 from unittest.mock import Mock, PropertyMock, patch
+
+import ddt
 
 from lti_consumer.exceptions import LtiError
 from lti_consumer.outcomes import OutcomeService, parse_grade_xml_body
-from lti_consumer.tests.unit.test_lti_xblock import TestLtiConsumerXBlock
 from lti_consumer.tests.test_utils import make_request
+from lti_consumer.tests.unit.test_lti_xblock import TestLtiConsumerXBlock
 
 REQUEST_BODY_TEMPLATE_VALID = textwrap.dedent("""
     <?xml version="1.0" encoding="UTF-8"?>
@@ -326,6 +327,7 @@ class TestParseGradeXmlBody(unittest.TestCase):
         self.assertEqual(action, 'ţéšţ_action')
 
 
+@ddt.ddt
 class TestOutcomeService(TestLtiConsumerXBlock):
     """
     Unit tests for OutcomeService
@@ -333,7 +335,17 @@ class TestOutcomeService(TestLtiConsumerXBlock):
 
     def setUp(self):
         super().setUp()
-        self.outcome_servce = OutcomeService(self.xblock)
+        self.outcome_service = OutcomeService(self.xblock)
+
+        # Set up user mock for LtiConsumerXBlock.get_lti_1p1_user_from_user_id method.
+        self.mock_get_user_id_patcher = patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p1_user_from_user_id')
+        self.addCleanup(self.mock_get_user_id_patcher.stop)
+        self.mock_get_user_id_patcher_enabled = self.mock_get_user_id_patcher.start()
+
+        mock_user = Mock()
+        mock_id = PropertyMock(return_value=1)
+        type(mock_user).id = mock_id
+        self.mock_get_user_id_patcher_enabled.return_value = mock_user
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
@@ -343,6 +355,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         Test replace result request returns with success indicator
         """
         request = make_request('')
+
         values = {
             'code': 'success',
             'description': 'Score for  is now 0.5',
@@ -351,7 +364,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         }
 
         self.assertEqual(
-            self.outcome_servce.handle_request(request).strip(),
+            self.outcome_service.handle_request(request).strip(),
             RESPONSE_BODY_TEMPLATE.format(**values).strip()
         )
 
@@ -362,7 +375,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         """
         request = make_request('')
         self.xblock.accept_grades_past_due = False
-        response = self.outcome_servce.handle_request(request)
+        response = self.outcome_service.handle_request(request)
 
         self.assertIn('failure', response)
         self.assertIn('Grade is past due', response)
@@ -376,7 +389,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         request = make_request('test_string')
 
         mock_parse.side_effect = LtiError
-        response = self.outcome_servce.handle_request(request)
+        response = self.outcome_service.handle_request(request)
         self.assertNotIn('TypeError', response)
         self.assertNotIn('a bytes-like object is required', response)
         self.assertIn('Request body XML parsing error', response)
@@ -389,7 +402,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         request = make_request('')
 
         mock_parse.side_effect = LtiError
-        response = self.outcome_servce.handle_request(request)
+        response = self.outcome_service.handle_request(request)
         self.assertIn('failure', response)
         self.assertIn('Request body XML parsing error', response)
 
@@ -403,10 +416,10 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         request = make_request('')
 
         mock_verify.side_effect = ValueError
-        self.assertIn('failure', self.outcome_servce.handle_request(request))
+        self.assertIn('failure', self.outcome_service.handle_request(request))
 
         mock_verify.side_effect = LtiError
-        self.assertIn('failure', self.outcome_servce.handle_request(request))
+        self.assertIn('failure', self.outcome_service.handle_request(request))
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
@@ -416,12 +429,9 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         Test user not found returns failure response
         """
         request = make_request('')
-        self.xblock.runtime.service = Mock(
-            return_value=Mock(
-                get_user_by_anonymous_id=Mock(return_value=None)
-            )
-        )
-        response = self.outcome_servce.handle_request(request)
+
+        self.mock_get_user_id_patcher_enabled.return_value = None
+        response = self.outcome_service.handle_request(request)
 
         self.assertIn('failure', response)
         self.assertIn('User not found', response)
@@ -434,7 +444,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         Test unsupported action returns unsupported response
         """
         request = make_request('')
-        response = self.outcome_servce.handle_request(request)
+        response = self.outcome_service.handle_request(request)
 
         self.assertIn('unsupported', response)
         self.assertIn('Target does not support the requested operation.', response)


### PR DESCRIPTION
### Description

In https://github.com/openedx/xblock-lti-consumer/pull/307, we added the ability to send a stable, static user identifier (i.e. external user ID) to fix failed launches with the QwikLabs tool. This is because the QwikLabs tool did not work with the course-anonymized user IDs we used to send (i.e. anonymous user IDs). Inadvertently, this change broke the LTI 1.1 Basic Outcomes Service and the LTI 2.0 Result Service for courses that use the external user ID (i.e. they have the `lti_consumer.enable_external_user_id_1p1_launches` `CourseWaffleFlag` enabled). The Basic Outcomes Service and Result Service handle grade pass backs. Because we now have two ways to identify a user in LTI 1.1/2.0, we must update the Basic Outcomes Service and Result Service to support both.

### Testing Instructions

Testing these is a little complex. I've tried to be as comprehensive as I can be with the instructions here, but please reach out if you have trouble.

**LTI 1.1 Basic Outcomes Service**

- Set up devstack.
- Create an LTI 1.1 component in Studio, following the instructions in the README.
- Set up your preferred API testing tool (e.g. Postman) to send a POST request.
    - URL: <BASIC_OUTCOMES_URL>
    - Body: raw
        - Be sure to update the `sourcedId` XML component appropriately.
    
    ```python
    <?xml version="1.0" encoding="UTF-8"?>
    <imsx_POXEnvelopeRequest xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
    <imsx_POXHeader>
      <imsx_POXRequestHeaderInfo>
        <imsx_version>V1.0</imsx_version>
        <imsx_messageIdentifier>999999123</imsx_messageIdentifier>
      </imsx_POXRequestHeaderInfo>
    </imsx_POXHeader>
    <imsx_POXBody>
      <replaceResultRequest>
        <resultRecord>
          <sourcedGUID>
            <sourcedId>course-v1%3AedX%2B1717N1%2BY2022N1:localhost%3A18000-1bca781ee09347a6800ad29c346abc07:1bc0b578-6f17-4e32-917a-94dc63edddda</sourcedId>
          </sourcedGUID>
          <result>
            <resultScore>
              <language>en</language>
              <textString>0.92</textString>
            </resultScore>
          </result>
        </resultRecord>
      </replaceResultRequest>
    </imsx_POXBody>
    </imsx_POXEnvelopeRequest>
    ```
    
- The `basic_outcomes_url` can be retrieved viewing the live LTI component in the LMS, if you’re using the SaLTIre tool, because it displays this value for you. If it does not, you can retrieve it by using the LTI rest endpoints view.
    - Go to `https://<LMS_DOMAIN>/courses/<COURSE_ID>/lti_rest_endpoints/`, find your component, and select the `lti_1_1_result_service_xml_endpoint`. Note that you should use `http` with devstack.
- Open a Python shell and install the `oauthlib` Python module.
    - Alternatively, you can open a Django shell in the LMS/Studio devstack shells. It is installed there as a necessary dependency of `xblock-lti-consumer`.
- Open a Python shell and enter the following commands. `client_key` and `client_secret` come from your LTI passport string. The ones below come from the SaLTIre testing tool, as described in the `xblock-lti-consumer` README file.
    
    ```python
    >>> from oauthlib import oauth1
    >>> client_key="test"
    >>> client_secret="secret"
    >>> client = oauth1.Client(client_key=client_key, client_secret=client_secret)
    >>> basic_outcomes_url = "http://localhost:18000/courses/course-v1:edX+1717N1+Y2022N1/xblock/block-v1:edX+1717N1+Y2022N1+type@lti_consumer+block@1bca781ee09347a6800ad29c346abc07/handler_noauth/outcome_service_handler"
    >>> xml_body = """<?xml version="1.0" encoding="UTF-8"?>
    <imsx_POXEnvelopeResponse xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
        <imsx_POXHeader>
            <imsx_POXResponseHeaderInfo>
                <imsx_version>V1.0</imsx_version>
                <imsx_messageIdentifier>999999123</imsx_messageIdentifier>
                <imsx_statusInfo>
                    <imsx_codeMajor>failure</imsx_codeMajor>
                    <imsx_severity>status</imsx_severity>
                    <imsx_description>User not found.</imsx_description>
                    <imsx_messageRefIdentifier>
                    </imsx_messageRefIdentifier>
                </imsx_statusInfo>
            </imsx_POXResponseHeaderInfo>
        </imsx_POXHeader>
        <imsx_POXBody></imsx_POXBody>
    </imsx_POXEnvelopeResponse>"""
    >>> uri, headers, body = client.sign(basic_outcomes_url, http_method="POST", body=xml_body, headers={"Content-Type": "text/xml"})
    ```
    
    - If you have issues with the `oauth_body_hash` not matching, make sure that your `xml_body` matches the body variable in `verify_oauth_body_signature`. A breakpoint can be helpful.
- `headers` should look something like this.

```python
{'Content-Type': 'text/xml', 'Authorization': 'OAuth oauth_nonce="5609288327616222561669665375", oauth_timestamp="1669665375", oauth_version="1.0", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="test", oauth_body_hash="vAVegN28HcixFW7OuHgfx0Ld%2Bdk%3D", oauth_signature="4Or9QJKG66jFHpZU6JeyNHcYdDk%3D"'}
```

- Take the Authorization header and use it in your preferred API testing tool (e.g. Postman). For example, in Postman, you should have something like the following header mapping.
- Note: If you’re switching between anonymous user IDs and external user IDs, you’ll need to update your XML in Postman and recompute the Authorization header using the instructions above.

**LTI 2.0 Result Service**

To send a Result Service request in devstack, follow these steps.

- Set up devstack.
- Create an LTI 1.1 component in Studio, following the instructions in the README.
- Set up your preferred API testing tool (e.g. Postman) to send a PUT/GET request.
    - Set the request method to GET or PUT.
    - URL: <RESULT_SERVICE_URL>
    - Body: raw
        - Be sure to update the JSON appropriately.
        - NOTE: Do NOT set the content type to JSON. Leave it as raw, text.
    
    ```python
    {
        "@context" : "http://purl.imsglobal.org/ctx/lis/v2/Result",
        "@type" : "Result",
        "resultScore" : 0.83,
        "comment" : "This is exceptional work."
    }
    ```
    
- The `result_service_url` can be retrieved viewing the live LTI component in the LMS, if you’re using the SaLTIre tool, because it displays this value for you. If it does not, you can retrieve it by using the LTI rest endpoints view.
    - Go to `https://<LMS_DOMAIN>/courses/<COURSE_ID>/lti_rest_endpoints/`, find your component, and select the `lti_2_0_result_service_json_endpoint`. Note that you should use `http` with devstack.
    - If you’re making a PUT request, under Headers, set the `Content Type` header to `application/vnd.ims.lis.v2.result+json`.
- Open a Python shell and install the `oauthlib` Python module.
    - Alternatively, you can open a Django shell in the LMS/Studio devstack shells. It is installed there as a necessary dependency of `xblock-lti-consumer`.
- Open a Python shell and enter the following commands. `client_key` and `client_secret` come from your LTI passport string. The ones below come from the SaLTIre testing tool, as described in the `xblock-lti-consumer` README file.
    
    ```python
    >>> from oauthlib import oauth1
    >>> client_key="test"
    >>> client_secret="secret"
    >>> client = oauth1.Client(client_key=client_key, client_secret=client_secret)
    >>> result_service_url = "http://localhost:18000/courses/course-v1:edX+1717N1+Y2022N1/xblock/block-v1:edX+1717N1+Y2022N1+type@lti_consumer+block@1bca781ee09347a6800ad29c346abc07/handler_noauth/result_service_handler/user/1bc0b578-6f17-4e32-917a-94dc63edddda"
    >>> json_body = """{
    >>>     "@context" : "http://purl.imsglobal.org/ctx/lis/v2/Result",
    >>>     "@type" : "Result",
    >>>     "resultScore" : 0.83,
    >>>     "comment": "This is exceptional work."
    >>> }"""
    >>> uri, headers, body = client.sign(result_service_url, http_method="PUT", body=json_body, headers={"Content-Type": "application/vnd.ims.lis.v2.result+json"})
    ```
    
    - If you have issues with the `oauth_body_hash` not matching, make sure that your `xml_body` matches the body variable in `verify_oauth_body_signature`. A breakpoint can be helpful.
        - Note: Be sure the `json_body` matches exactly what is in Postman, including whitespace characters (e.g. spaces versus tabs).
- `headers` should look something like this.

```python
{'Content-Type': 'text/xml', 'Authorization': 'OAuth oauth_nonce="5609288327616222561669665375", oauth_timestamp="1669665375", oauth_version="1.0", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="test", oauth_body_hash="vAVegN28HcixFW7OuHgfx0Ld%2Bdk%3D", oauth_signature="4Or9QJKG66jFHpZU6JeyNHcYdDk%3D"'}
```

- Take the Authorization header and use it in your preferred API testing tool (e.g. Postman). For example, in Postman, you should have something like the following header mapping.

```python
Authorization: OAuth oauth_nonce="5609288327616222561669665375", oauth_timestamp="1669665375", oauth_version="1.0", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="test", oauth_body_hash="vAVegN28HcixFW7OuHgfx0Ld%2Bdk%3D", oauth_signature="4Or9QJKG66jFHpZU6JeyNHcYdDk%3D"
```
- Note: If you’re switching between anonymous user IDs and external user IDs, you’ll need to update your URL in Postman and recompute the Authorization header using the instructions above.

### Manual Testing

I performed the following manual tests.

* Tested LTI 1.1/2.0 component with `lti_consumer.enable_external_user_id_1p1_launches` flag on, sent Basic Outcomes Service request with external user ID
* Tested LTI 1.1/2.0 component with `lti_consumer.enable_external_user_id_1p1_launches` flag off, sent Basic Outcomes Service request with anonymous user ID
* Tested LTI 1.1/2.0 component with `lti_consumer.enable_external_user_id_1p1_launches` flag on, sent Result Service request with external user ID
* Tested LTI 1.1/2.0 component with `lti_consumer.enable_external_user_id_1p1_launches` flag off, sent Result Service request with anonymous user ID