### PR TITLE
fix: remove lms specific waffle check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+7.0.3 - 2022-12-02
+------------------
+* Removed check against LMS specific `database_config_enabled` in LtiConfiguration model.
+
 7.0.2 - 2022-11-29
 ------------------
 * Fix the LTI 1.1 Outcome Results Service to be able to tie an outcome pass back to a user when the user ID is an

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.0.2'
+__version__ = '7.0.3'

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -29,7 +29,6 @@ from lti_consumer.utils import (
     get_lti_ags_lineitems_url,
     get_lti_deeplinking_response_url,
     get_lti_nrps_context_membership_url,
-    database_config_enabled,
 )
 
 log = logging.getLogger(__name__)
@@ -240,10 +239,6 @@ class LtiConfiguration(models.Model):
                 "config_store": _("LTI Configuration stores on XBlock needs a block location set."),
             })
         if self.version == self.LTI_1P3 and self.config_store == self.CONFIG_ON_DB:
-            if not database_config_enabled(self.location.course_key):
-                raise ValidationError({
-                    "config_store": _("LTI Configuration stores on database is not enabled."),
-                })
             if self.lti_1p3_tool_public_key == "" and self.lti_1p3_tool_keyset_url == "":
                 raise ValidationError({
                     "config_store": _(

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -359,15 +359,10 @@ class TestLtiConfigurationModel(TestCase):
 
         self.lti_1p3_config.config_store = self.lti_1p3_config.CONFIG_ON_DB
 
-        with patch("lti_consumer.models.database_config_enabled", return_value=False),\
-             self.assertRaises(ValidationError):
-            self.lti_1p3_config_db.clean()
-
         self.lti_1p3_config_db.lti_1p3_tool_keyset_url = ''
         self.lti_1p3_config_db.lti_1p3_tool_public_key = ''
 
-        with patch("lti_consumer.models.database_config_enabled", return_value=True),\
-             self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError):
             self.lti_1p3_config_db.clean()
 
         self.lti_1p3_config.lti_1p3_proctoring_enabled = True


### PR DESCRIPTION
I'm running into two problems with this check when this code is run in edx-exams. Location isn't required on this model so location.course_key may fail but more importantly `database_config_enabled` can only run in the LMS. Checking if location exists first would technically fix this since a location implies this is running in the LMS (for now) but I'm coming to the conclusion that this check should probably not exist here.

All other instances of `database_config_enabled` occur within the lti_xblock.py which is totally fine to call into the LMS compatibility layer but baking this function into the data model feels like something that will catch us again later. The waffle flag already gates the UI behavior, do we really need this check on the model also?

Let know if I'm missing some good arguments for keeping this in, otherwise I propose we remove it.

