### PR TITLE
feat: adds setting to prevent nrps pii

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+7.1.0 - 2022-12-09
+------------------
+* Add support for platform setting `LTI_NRPS_DISALLOW_PII` to prevent sharing of pii over the names and roles
+  provisioning service.
+
 7.0.3 - 2022-12-02
 ------------------
 * Removed check against LMS specific `database_config_enabled` in LtiConfiguration model.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.0.3'
+__version__ = '7.1.0'

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -305,9 +305,10 @@ def get_event_tracker():  # pragma: nocover
     except ModuleNotFoundError:
         return None
 
+
 def nrps_pii_disallowed():
     """
     Check if platform disallows sharing pii over NRPS
     """
     return (hasattr(settings, 'LTI_NRPS_DISALLOW_PII') and
-        settings.LTI_NRPS_DISALLOW_PII is True)
+            settings.LTI_NRPS_DISALLOW_PII is True)

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -4,6 +4,7 @@ Compatibility layer to isolate core-platform method calls from implementation.
 import logging
 from typing import Callable
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import ModelForm
 from opaque_keys.edx.keys import CourseKey
@@ -303,3 +304,10 @@ def get_event_tracker():  # pragma: nocover
         return tracker
     except ModuleNotFoundError:
         return None
+
+def nrps_pii_disallowed():
+    """
+    Check if platform disallows sharing pii over NRPS
+    """
+    return (hasattr(settings, 'LTI_NRPS_DISALLOW_PII') and
+        settings.LTI_NRPS_DISALLOW_PII is True)

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -682,7 +682,8 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
         Overrides ModelViewSet's `get_serializer_class` method.
         Checks if PII fields can be exposed and returns appropiate serializer.
         """
-        if get_lti_pii_sharing_state_for_course(self.request.lti_configuration.location.course_key):
+        if (not compat.nrps_pii_disallowed() and
+                get_lti_pii_sharing_state_for_course(self.request.lti_configuration.location.course_key)):
             return LtiNrpsContextMembershipPIISerializer
         else:
             return LtiNrpsContextMembershipBasicSerializer


### PR DESCRIPTION
### [MST-1737](https://2u-internal.atlassian.net/browse/MST-1737)

This is a temporary solution. We would like to enable PII in an LTI1.3 launch but turning that flag on would allow the tool to grab PII for the entire course roster via NRPS. We have not fully evaluated the privacy concerns if that is allowed. For the time being this platform setting can wholly disable PII over NRPS to avoid the issue.