### PR TITLE
[BD-13][BB-6926] refactor: fix module-containing imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+7.3.0 - 2023-01-30
+------------------
+* Rename edx-platform import of ``get_module_for_descriptor_internal``.
+
 7.2.3 - 2023-01-24
 ------------------
 * This release fixes a bug in the way that the PII sharing consent dialog renders. The bug resulted in the "OK" and

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.2.3'
+__version__ = '7.3.0'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -749,7 +749,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         This is for backwards compatibility with the XModule API.
         Some LMS code still assumes a descriptor attribute on the XBlock object.
-        See courseware.module_render.rebind_noauth_module_to_user.
         """
         return self
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -100,7 +100,7 @@ def load_block_as_user(location):  # pragma: nocover
     """
     # pylint: disable=import-error,import-outside-toplevel
     from crum import get_current_user, get_current_request
-    from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
+    from lms.djangoapps.courseware.block_render import get_block_for_descriptor_internal
     from openedx.core.lib.xblock_utils import request_token
 
     # Retrieve descriptor from modulestore
@@ -114,7 +114,7 @@ def load_block_as_user(location):  # pragma: nocover
             return descriptor
 
         # If not load this block to bind it onto the user
-        get_module_for_descriptor_internal(
+        get_block_for_descriptor_internal(
             user=user,
             descriptor=descriptor,
             student_data=None,
@@ -138,14 +138,14 @@ def _load_block_as_anonymous_user(location, descriptor):  # pragma: nocover
     # pylint: disable=import-error,import-outside-toplevel
     from crum import impersonate
     from django.contrib.auth.models import AnonymousUser
-    from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
+    from lms.djangoapps.courseware.block_render import get_block_for_descriptor_internal
 
     # ensure `crum.get_current_user` returns AnonymousUser. It returns None when outside
     # of request scope which causes error during block loading.
     user = AnonymousUser()
     with impersonate(user):
         # Load block, attaching it to AnonymousUser
-        get_module_for_descriptor_internal(
+        get_block_for_descriptor_internal(
             user=user,
             descriptor=descriptor,
             student_data=None,


### PR DESCRIPTION
## Description

`module_render` and `get_module_for_descriptor_internal` were renamed in https://github.com/openedx/edx-platform/pull/31475. This PR fixes imports.

## Testing instructions

See the testing instructions for https://github.com/openedx/edx-platform/pull/31475