### PR TITLE
feanil/django pyfs

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '7.3.0'
+__version__ = '8.0.0'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@
 
 attrs
 lxml
-bleach
+bleach>=6.0.0
 django
 oauthlib
 mako

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -108,7 +108,6 @@ django==3.2.16
     #   django-config-models
     #   django-crum
     #   django-filter
-    #   django-pyfs
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
@@ -122,8 +121,6 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
 django-filter==22.1
-    # via -r requirements/test.txt
-django-pyfs==3.2.0
     # via -r requirements/test.txt
 django-waffle==3.0.0
     # via
@@ -157,14 +154,12 @@ filelock==3.9.0
 fs==2.4.16
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
     #   -r requirements/test.txt
-    #   django-pyfs
     #   openedx-django-pyfs
     #   xblock-sdk
 future==0.18.3

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,7 +5,6 @@
 
 coveralls
 ddt
-django-pyfs
 djangorestframework
 edx_lint
 mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -79,7 +79,6 @@ dill==0.3.6
     #   django-config-models
     #   django-crum
     #   django-filter
-    #   django-pyfs
     #   djangorestframework
     #   edx-django-utils
     #   jsonfield
@@ -94,8 +93,6 @@ django-crum==0.7.9
     #   edx-django-utils
 django-filter==22.1
     # via -r requirements/base.txt
-django-pyfs==3.2.0
-    # via -r requirements/test.in
 django-waffle==3.0.0
     # via
     #   -r requirements/base.txt
@@ -120,13 +117,11 @@ edx-opaque-keys[django]==2.3.0
 fs==2.4.16
     # via
     #   -r requirements/base.txt
-    #   django-pyfs
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   django-pyfs
     #   openedx-django-pyfs
     #   xblock-sdk
 future==0.18.3


### PR DESCRIPTION
- refactor: Don't claim django-pyfs as a direct dependency.
- chore: Run `make upgrade`

Relates to https://github.com/openedx/django-pyfs/issues/101