### PR TITLE
fix: inappropriate instructions for inline PII sharing consent dialog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Please See the [releases tab](https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+8.0.1 - 2023-02-03
+------------------
+* This releases fixes the PII sharing consent dialog for inline launches to no longer refer to a nonexistent
+  "Cancel" button.
+
 8.0.0 - 2023-01-31
 ------------------
 * Update to work with bleachk>=6.0.0 and make that an explicit requirement in

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '8.0.0'
+__version__ = '8.0.1'

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -154,15 +154,21 @@ function LtiConsumerXBlock(runtime, element) {
 
         function renderPIIConsentPromptIfRequired(onSuccess, showCancelButton=true) {
             if (askToSendUsername && askToSendEmail) {
-                msg = gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+                msg = "Click OK to have your username and e-mail address sent to a 3rd party application.";
             } else if (askToSendUsername) {
-                msg = gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+                msg = "Click OK to have your username sent to a 3rd party application.";
             } else if (askToSendEmail) {
-                msg = gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+                msg = "Click OK to have your e-mail address sent to a 3rd party application.";
             } else {
                 onSuccess("OK");
                 return;
             }
+
+            if (showCancelButton) {
+                msg += "\n\nClick Cancel to return to this page without sending your information.";
+            }
+
+            msg = gettext(msg);
             $.when(confirmDialog(msg, $(this), showCancelButton)).then(onSuccess);
         }
 


### PR DESCRIPTION
This commit fixes inappropriate instructions displayed when collecting PII sharing consent before an inline LTI launch. Previously, the instructions said, "Click OK to have your [username (and) e-mail address] sent to a 3rd party application. Click Cancel to return to this page without sending your information." The latter sentence does not make sense in the context of an inline launch, because there is no cancel button. This commit modifies the inline PII sharing consent dialog to say, "Click OK to have your [username (and) e-mail address] sent to a 3rd party application.""

### Before

<img width="710" alt="image" src="https://user-images.githubusercontent.com/11871801/216635521-6e9157df-5231-47a7-93fa-456e817d30b7.png">

### After

<img width="707" alt="image" src="https://user-images.githubusercontent.com/11871801/216635231-d5a174a3-ceee-4162-b51a-6014a728e20f.png">
