### PR TITLE
docs: fix translations update instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ inside project root directory:
 
 .. code:: bash
 
-    $ tx pull -f --mode=reviewed -l en,ar,es_419,fr,he,hi,ko_KR,pt_BR,ru,zh_CN
+    $ tx pull -f --mode=reviewed
 
 Further Development Info
 ------------------------


### PR DESCRIPTION
closes #354

Removes from the README.md the incorrect instructions to update only some languages instead of all.