### PR TITLE
feat: add logging for access token view and key handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.0.3 - 2023-04-18
+------------------
+* Add logging for error cases in the access_token_endpoint view and the key handler classes.
+
 9.0.2 - 2023-04-12
 ------------------
 * Updated PII JS so strings can be extracted for translation.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.0.2'
+__version__ = '9.0.3'

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -417,10 +417,20 @@ class LtiConsumer1p3:
         # Check if all required claims are present
         for required_claim in LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS:
             if required_claim not in token_request_data.keys():
-                raise exceptions.MissingRequiredClaim(f'The required claim {required_claim} is missing from the JWT.')
+                error_msg = (
+                    f'The required claim {required_claim} is missing from the OAuth 2.0 Client-Credentials '
+                    'Grant JWT.'
+                )
+                log.warning(error_msg)
+                raise exceptions.MissingRequiredClaim(error_msg)
 
         # Check that grant type is `client_credentials`
-        if token_request_data['grant_type'] != 'client_credentials':
+        grant_type = token_request_data['grant_type']
+        if grant_type != 'client_credentials':
+            log.warning(
+                'The required grant_type parameter in the OAuth 2.0 Client-Credentials Grant JWT was expected to be '
+                f'client_credentials but was {grant_type} instead.'
+            )
             raise exceptions.UnsupportedGrantType()
 
         # Validate JWT token


### PR DESCRIPTION
JIRA: [MST-1853](https://2u-internal.atlassian.net/browse/MST-1853)

This commit adds logging for error cases in the access_token_endpoint view and the key handler classes. This will make it easier to debug issues with requesting or using LTI 1.3 access tokens.