### PR TITLE
Proof of concept: ACS scope handling

### DIFF
--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -65,6 +65,10 @@ LTI_1P3_ACCESS_TOKEN_SCOPES = [
 
     # LTI-NRPS Scopes
     'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly',
+
+    # ACS Scopes
+    # TODO: This isn't necessarily the best place for this.
+    'https://purl.imsglobal.org/spec/lti-ap/claim/acs',
 ]
 
 

--- a/lti_consumer/lti_1p3/extensions/rest_framework/permissions.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/permissions.py
@@ -99,3 +99,24 @@ class LtiNrpsContextMembershipsPermissions(LTIBasePermissions):
             ]
 
         return scopes
+
+
+class LtiProctoringAcsPermissions(LTIBasePermissions):
+    """
+    LTI ACS Permissions.
+
+    This checks if the token included in the request
+    has the allowed scopes to perform ACS actions
+    (insert action examples here)
+
+    Link to relevant docs: (ims global docs url here)
+    """
+
+    def get_permission_scopes(self, request, view):
+        """
+        Return the LTI ACS scope.
+        There is only one: http://www.imsglobal.org/spec/proctoring/v1p0#h.ckrfa92a27mw
+        """
+        return [
+            'https://purl.imsglobal.org/spec/lti-ap/claim/acs',
+        ]

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -824,11 +824,15 @@ def start_proctoring_assessment_endpoint(request):
                 django_cache_timeout=timeout
             )
 
-    LTI_1P3_PROCTORING_ASSESSMENT_STARTED.send(
+    lti_proctoring_response = LTI_1P3_PROCTORING_ASSESSMENT_STARTED.send(
         sender=None,
         attempt_number=proctoring_response["attempt_number"],
         resource_link=proctoring_response["resource_link"],
         user_id=request.user.id,
     )
 
-    return JsonResponse(data={})
+    response_data = lti_proctoring_response[0][1]
+    # if we have more than one receiver, how hard would this code be to modify?
+    # Note: must abide by LTI rules. So have handler that warns "hey you're data's the wrong shape" if it is
+
+    return JsonResponse(data={response_data})


### PR DESCRIPTION
Proof of concept for handling ACS scopes for both the access_token endpoint and when checking ACS permissions for the actual ACS endpoint in edx-exams.

This PR is not meant to be merged.