### PR TITLE
feat: add full name as a LTI PII field

### DIFF
--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -46,6 +46,7 @@ class Lti1p3LaunchData:
     * resource_link_id (required): A unique identifier that is guaranteed to be unique for each placement of the LTI
         link.
     * preferred_username (optional): The user's username.
+    * name (optional): The user's full name.
     * email (optional): The user's email.
     * external_user_id (optional): A unique identifier for the user that is requesting the LTI 1.3 launch that can be
         shared externally. The identifier must be stable to the issuer. This value will be sent to the the Tool in the
@@ -76,6 +77,7 @@ class Lti1p3LaunchData:
     config_id = field()
     resource_link_id = field()
     preferred_username = field(default=None)
+    name = field(default=None)
     email = field(default=None)
     external_user_id = field(default=None)
     launch_presentation_document_target = field(default=None)

--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -155,7 +155,8 @@ class LtiConsumer1p1:
             roles,
             result_sourcedid,
             person_sourcedid=None,
-            person_contact_email_primary=None
+            person_contact_email_primary=None,
+            person_name_full=None,
     ):
         """
         Set user data/roles
@@ -167,6 +168,7 @@ class LtiConsumer1p1:
                 and uniquely identifies a row and column within the Tool Consumer gradebook
             person_sourcedid (string):  LIS identifier for the user account performing the launch
             person_contact_email_primary (string):  Primary contact email address of the user
+            person_name_full (string): Full name of the user
         """
         self.lti_user_data = {
             'user_id': user_id,
@@ -174,7 +176,7 @@ class LtiConsumer1p1:
             'lis_result_sourcedid': result_sourcedid,
         }
 
-        # Additonal user identity data
+        # Additional user identity data
         # Optional user data that can be sent to the tool, if the block is configured to do so
         if person_sourcedid:
             self.lti_user_data.update({
@@ -184,6 +186,11 @@ class LtiConsumer1p1:
         if person_contact_email_primary:
             self.lti_user_data.update({
                 'lis_person_contact_email_primary': person_contact_email_primary,
+            })
+
+        if person_name_full:
+            self.lti_user_data.update({
+                'lis_person_name_full': person_name_full,
             })
 
     def set_context_data(self, context_id, context_title, context_label):

--- a/lti_consumer/lti_1p1/tests/test_consumer.py
+++ b/lti_consumer/lti_1p1/tests/test_consumer.py
@@ -193,6 +193,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
         roles = 'roles'
         result_sourcedid = 'result_sourcedid'
         person_sourcedid = 'person_sourcedid'
+        person_name_full = 'person_name_full'
         person_contact_email_primary = 'person_contact_email_primary'
         context_id = 'context_id'
         context_title = 'context_title'
@@ -210,7 +211,8 @@ class TestLtiConsumer1p1(unittest.TestCase):
             roles,
             result_sourcedid,
             person_sourcedid=person_sourcedid,
-            person_contact_email_primary=person_contact_email_primary
+            person_contact_email_primary=person_contact_email_primary,
+            person_name_full=person_name_full,
         )
         self.lti_consumer.set_context_data(context_id, context_title, context_label)
         self.lti_consumer.set_outcome_service_url(outcome_service_url)
@@ -229,6 +231,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
             'lis_result_sourcedid': result_sourcedid,
             'lis_person_sourcedid': person_sourcedid,
             'lis_person_contact_email_primary': person_contact_email_primary,
+            'lis_person_name_full': person_name_full,
             'context_id': context_id,
             'context_label': context_label,
             'context_title': context_title,

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -153,7 +153,7 @@ class LtiConsumer1p3:
             "https://purl.imsglobal.org/spec/lti/claim/roles": self._get_user_roles(role)
         }
 
-        # Additonal user identity claims
+        # Additional user identity claims
         # Optional user data that can be sent to the tool, if the block is configured to do so
         if full_name:
             self.lti_claim_user_data.update({

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -187,6 +187,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         lti_consumer.set_user_data(
             user_id=user_id,
             role=user_role,
+            full_name=launch_data.name,
             email_address=launch_data.email,
             preferred_username=launch_data.preferred_username,
         )

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -149,14 +149,29 @@ function LtiConsumerXBlock(runtime, element) {
         var $element = $(element);
         var $ltiContainer = $element.find('.lti-consumer-container');
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
+        var askToSendFullName = $ltiContainer.data('ask-to-send-full-name') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
         var ltiVersion = $ltiContainer.data('lti-version');
 
         function renderPIIConsentPromptIfRequired(onSuccess, showCancelButton=true) {
-            if (askToSendUsername && askToSendEmail) {
+            if (askToSendUsername && askToSendFullName && askToSendEmail) {
+                msg = gettext(
+                    'Click OK to have your username, full name, and e-mail address sent to a 3rd party application.'
+                );
+            }
+            else if (askToSendUsername && askToSendEmail) {
                 msg = gettext('Click OK to have your username and e-mail address sent to a 3rd party application.');
-            } else if (askToSendUsername) {
+            }
+            else if (askToSendUsername && askToSendFullName) {
+                msg = gettext('Click OK to have your username and full name sent to a 3rd party application.');
+            }
+            else if (askToSendFullName && askToSendEmail) {
+                msg = gettext('Click OK to have your full name and e-mail address sent to a 3rd party application.');
+            }
+            else if (askToSendUsername) {
                 msg = gettext('Click OK to have your username sent to a 3rd party application.');
+            } else if (askToSendFullName) {
+                msg = gettext('Click OK to have your full name sent to a 3rd party application.');
             } else if (askToSendEmail) {
                 msg = gettext('Click OK to have your e-mail address sent to a 3rd party application.');
             } else {

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -17,6 +17,7 @@
     id="${element_id}"
     class="${element_class} lti-consumer-container"
     data-ask-to-send-username="${ask_to_send_username}"
+    data-ask-to-send-full-name="${ask_to_send_full_name}"
     data-ask-to-send-email="${ask_to_send_email}"
     data-lti-version="${lti_version}"
 >

--- a/lti_consumer/tests/test_utils.py
+++ b/lti_consumer/tests/test_utils.py
@@ -99,8 +99,8 @@ def get_mock_lti_configuration(editable):
     Returns a mock object of lti-configuration service
 
     Arguments:
-        editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username' and
-        'ask_to_send_email') are editable.
+        editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name',
+        and 'ask_to_send_email') are editable.
     """
     lti_configuration = Mock()
     lti_configuration.configuration = Mock()


### PR DESCRIPTION
This commits adds the ability to share a learner's full name in both LTI 1.1 and LTI 1.3 launches. In LTI 1.1, the full name is sent as the `lis_person_name_full` LTI parameter. In LTI 1.3, the full name is sent as the `name` ID token claim.

The full name corresponds to the learner's name as recorded by the `UserProfile` model in the LMS.

Enabling the transmission of full name in either version of LTI follows the existing pattern for PII sharing. In order for full name to be shared via an LTI launch, the `CourseAllowPIISharingInLTIFlag` configuration model must be enabled for the course, and the `Request user's full name` XBlock field must be enabled in the XBlock describing the particular LTI integration.

Please note that this commit does not add the ability to share a learner's full name via the LTI 1.3 Names and Role Provisioning Services context membership endpoint because that behavior already exists.

### PII Sharing Consent Message
<img width="962" alt="Screenshot 2023-04-27 at 4 28 24 PM" src="https://user-images.githubusercontent.com/11871801/235191091-286a63e1-5e15-40e5-afc5-a394780eb162.png">

### LTI 1.1 Full Name Parameter
<img width="957" alt="Screenshot 2023-04-27 at 4 28 42 PM" src="https://user-images.githubusercontent.com/11871801/235191239-48302e6e-0d66-4e46-8acf-31a7ae2e0457.png">


### LTI 1.3 Full Name Claim
<img width="470" alt="Screenshot 2023-04-27 at 4 28 13 PM" src="https://user-images.githubusercontent.com/11871801/235191215-5b5e4e70-f8c1-4982-b068-c5306f0ad91c.png">
