### PR TITLE
build: bump library version and add CHANGELOG entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.1.0 - 2023-04-28
+------------------
+* Add full name as an LTI parameter to LTI 1.1 launches as the "lis_person_name_full" parameter.
+* Add full name as an LTI parameter to LTI 1.3 launches as the "name" ID token claim.
+
 9.0.4 - 2023-04-25
 ------------------
 * Standardize translation directory to comply with openedx-translations.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.0.4'
+__version__ = '9.1.0'


### PR DESCRIPTION
I neglected to bump the library version and update the CHANGELOG for the changes made in #363. This commit corrects that.