### PR TITLE
feat: support assessment control claims

### DIFF
--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -5,6 +5,8 @@ by users of this library.
 
 from attrs import define, field, validators
 
+from lti_consumer.lti_1p3.constants import LTI_PROCTORING_ASSESSMENT_CONTROL_ACTIONS
+
 
 @define
 class Lti1p3ProctoringLaunchData:
@@ -27,6 +29,14 @@ class Lti1p3ProctoringLaunchData:
     """
     attempt_number = field()
     start_assessment_url = field(default=None)
+    assessment_control_url = field(default=None)
+    assessment_control_actions = field(
+        default=[],
+        validator=[validators.deep_iterable(
+            member_validator=validators.in_(LTI_PROCTORING_ASSESSMENT_CONTROL_ACTIONS),
+            iterable_validator=validators.instance_of(list),
+        )],
+    )
 
 
 @define

--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -26,6 +26,8 @@ class Lti1p3ProctoringLaunchData:
         assessment message to after it has completed the proctoring setup and verification. This attribute is required
         if the message_type attribute of the Lti1p3LaunchData instance is "LtiStartProctoring". It is optional and
         unused otherwise.
+    * assessment_control_url (optional): The Platform URL that the Tool will send assessment control messages to.
+    * assessment_control_actions (optional): A list of assessment control actions supported by the platform.
     """
     attempt_number = field()
     start_assessment_url = field(default=None)

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -85,7 +85,14 @@ class LTI_1P3_CONTEXT_TYPE(Enum):  # pylint: disable=invalid-name
     course_template = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate'
 
 
-LTI_PROCTORING_DATA_KEYS = ['attempt_number', 'resource_link_id', 'session_data', 'start_assessment_url', 'assessment_control_url', 'assessment_control_actions']
+LTI_PROCTORING_DATA_KEYS = [
+    'attempt_number',
+    'resource_link_id',
+    'session_data',
+    'start_assessment_url',
+    'assessment_control_url',
+    'assessment_control_actions'
+]
 
 LTI_PROCTORING_ASSESSMENT_CONTROL_ACTIONS = [
     'pauseRequest',

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -85,4 +85,12 @@ class LTI_1P3_CONTEXT_TYPE(Enum):  # pylint: disable=invalid-name
     course_template = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate'
 
 
-LTI_PROCTORING_DATA_KEYS = ['attempt_number', 'resource_link_id', 'session_data', 'start_assessment_url']
+LTI_PROCTORING_DATA_KEYS = ['attempt_number', 'resource_link_id', 'session_data', 'start_assessment_url', 'assessment_control_url', 'assessment_control_actions']
+
+LTI_PROCTORING_ASSESSMENT_CONTROL_ACTIONS = [
+    'pauseRequest',
+    'resumeRequest',
+    'terminateRequest',
+    'update',
+    'flagRequest',
+]

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -809,6 +809,17 @@ class LtiProctoringConsumer(LtiConsumer1p3):
 
         return proctoring_claims
 
+    def get_assessment_control_claims(self):
+        """
+        Returns LTI Proctoring Services ACS Claim to be injected in the LTI launch message.
+        """
+        return {
+            "https://purl.imsglobal.org/spec/lti-ap/claim/acs": {
+                "assessment_control_url": self.proctoring_data.get("assessment_control_url"),
+                "actions": self.proctoring_data.get("assessment_control_actions"),
+            }
+        }
+
     def get_end_assessment_claims(self):
         """
         Returns claims specific to LTI Proctoring Services LtiEndAssessment LTI launch message,
@@ -842,6 +853,9 @@ class LtiProctoringConsumer(LtiConsumer1p3):
             raise ValueError('lti_message_hint must \"LtiStartProctoring\" or \"LtiEndAssessment\".')
 
         self.set_extra_claim(proctoring_claims)
+
+        if self.proctoring_data.get("assessment_control_url"):
+            self.set_extra_claim(self.get_assessment_control_claims())
 
         return super().generate_launch_request(preflight_response)
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -809,7 +809,7 @@ class LtiProctoringConsumer(LtiConsumer1p3):
 
         return proctoring_claims
 
-    def get_assessment_control_claims(self):
+    def get_assessment_control_claim(self):
         """
         Returns LTI Proctoring Services ACS Claim to be injected in the LTI launch message.
         """
@@ -855,7 +855,7 @@ class LtiProctoringConsumer(LtiConsumer1p3):
         self.set_extra_claim(proctoring_claims)
 
         if self.proctoring_data.get("assessment_control_url"):
-            self.set_extra_claim(self.get_assessment_control_claims())
+            self.set_extra_claim(self.get_assessment_control_claim())
 
         return super().generate_launch_request(preflight_response)
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -847,15 +847,18 @@ class LtiProctoringConsumer(LtiConsumer1p3):
 
         if launch_data.message_type == "LtiStartProctoring":
             proctoring_claims = self.get_start_proctoring_claims()
+
+            # Enable ACS if assessment_control_url is present on the launch data.
+            # Normally we would enable this using a field on the LtiConfiguration model like other
+            # Advantage services, but this isn't actually optional or configurable for Open edX.
+            if self.proctoring_data.get("assessment_control_url"):
+                self.set_extra_claim(self.get_assessment_control_claim())
         elif launch_data.message_type == "LtiEndAssessment":
             proctoring_claims = self.get_end_assessment_claims()
         else:
             raise ValueError('lti_message_hint must \"LtiStartProctoring\" or \"LtiEndAssessment\".')
 
         self.set_extra_claim(proctoring_claims)
-
-        if self.proctoring_data.get("assessment_control_url"):
-            self.set_extra_claim(self.get_assessment_control_claim())
 
         return super().generate_launch_request(preflight_response)
 

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -275,7 +275,9 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
             lti_consumer.set_proctoring_data(
                 attempt_number=launch_data.proctoring_launch_data.attempt_number,
                 session_data=session_data,
-                start_assessment_url=launch_data.proctoring_launch_data.start_assessment_url
+                start_assessment_url=launch_data.proctoring_launch_data.start_assessment_url,
+                assessment_control_url=launch_data.proctoring_launch_data.assessment_control_url,
+                assessment_control_actions=launch_data.proctoring_launch_data.assessment_control_actions,
             )
         elif launch_data.message_type == 'LtiEndAssessment':
             lti_consumer.set_proctoring_data(


### PR DESCRIPTION
### [MST-1846](https://2u-internal.atlassian.net/browse/MST-1846)

Adds optional support for the proctoring assessment control service (ACS)

Example of how to use this in edx-exams: https://github.com/edx/edx-exams/pull/122