### PR TITLE
fix: ensure platform name is string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,11 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
-921.0 - 2023-05-02
+9.2.1 - 2023-05-02
+------------------
+* Bug fix for adding platform name as an LTI parameter
+
+9.2.0 - 2023-05-02
 ------------------
 * Add platform name as an LTI parameter to LTI 1.1 launches as the "tool_consumer_info_product_family_code" parameter.
 * Add platform name as an LTI parameter to LTI 1.3 launches as the "platform instance" claim.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.2.0'
+__version__ = '9.2.1'

--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -283,7 +283,7 @@ class LtiConsumer1p1:
             # Parameters required for grading:
             'resource_link_id': resource_link_id,
 
-            'tool_consumer_info_product_family_code': settings.PLATFORM_NAME,
+            'tool_consumer_info_product_family_code': str(settings.PLATFORM_NAME),
         }
 
         # Check if user data is set, then append it to lti message

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -355,8 +355,8 @@ class LtiConsumer1p3:
             # Platform instance claim
             # The GUID must be consistent across platform deployments, so we have opted to generate a UUID
             # based on a namespace identifier and the platform name itself.
-            guid = uuid.uuid5(uuid.NAMESPACE_DNS, settings.PLATFORM_NAME)
-            platform_instance_claim = {'guid': str(guid), 'name': settings.PLATFORM_NAME}
+            guid = uuid.uuid5(uuid.NAMESPACE_DNS, str(settings.PLATFORM_NAME))
+            platform_instance_claim = {'guid': str(guid), 'name': str(settings.PLATFORM_NAME)}
             platform_instance_claim = {
                 "https://purl.imsglobal.org/spec/lti/claim/tool_platform": platform_instance_claim
             }


### PR DESCRIPTION
Typecast `PLATFORM_NAME` to a string to ensure that it can be parsed correctly by Oauth code. This fix will unblock the release of this library in edx-platform, which is currently blocked by failing tests: https://github.com/openedx/edx-platform/pull/32166.