### PR TITLE
fix: log user_id on lti launch failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 
 Unreleased
 ~~~~~~~~~~
+* Improved logging for Proctoring LTI 1.3 launch failure.
 
 9.5.0 - 2023-05-08
 ------------------

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -777,7 +777,7 @@ def start_proctoring_assessment_endpoint(request):
         log.warning(
             f'There was a cache miss trying to fetch the launch data during an LTI 1.3 proctoring StartAssessment '
             f'launch when using the cache key {launch_data_key}. The LtiConfiguration config_id is '
-            f'{lti_config.config_id}.'
+            f'{lti_config.config_id} the user_id is {request.user.id}.'
         )
         return render(request, 'html/lti_proctoring_start_error.html', status=HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
A common launch failure is missing/incorrect cookies that cause the user_id to be None. This makes it a lot easier to identify that problem without digging around.