### PR TITLE
feat: allow proctoring start from iframe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,16 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 
 Unreleased
 ~~~~~~~~~~
-* Improved logging for Proctoring LTI 1.3 launch failure.
+
+9.5.2 - 2023-05-24
+------------------
+* Allow start_proctoring_assessment_endpoint from an iframe during proctoring services launch.
 
 9.5.1 - 2023-05-19
 ------------------
 * Added gate to ensure the ACS scope is only added when using the LtiProctoringConsumer
 * Moved scope validation to a helper function
+* Improved logging for Proctoring LTI 1.3 launch failure.
 
 9.5.0 - 2023-05-08
 ------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.5.1'
+__version__ = '9.5.2'

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -728,6 +728,7 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 @csrf_exempt
+@xframe_options_exempt
 @require_http_methods(['POST'])
 def start_proctoring_assessment_endpoint(request):
     """


### PR DESCRIPTION
Allows for start proctoring message result to be rendered in an iframe. This isn't full support for proctoring inside an iframe there are still issues with rendering our learning MFE this way. This does unblock testing the launch flow at minimum.