### PR TITLE
[FC-0009] feat: For LTI 1.1, show a warning in Studio if lti_id is not right

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+* Show a warning in Studio if an LTI 1.1 consumer has an invalid `lti_id`.
+
 9.5.2 - 2023-05-24
 ------------------
 * Allow start_proctoring_assessment_endpoint from an iframe during proctoring services launch.

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -694,8 +694,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # a new LTI ID before they've added it to advanced settings, but we do want to warn them about it.
         # If we put this check in validate_field_data(), the settings editor wouldn't let them save changes.
         if self.lti_version == "lti_1p1" and self.lti_id:
-            lti_passport_ids = [lti_passport.split(':')[0] for lti_passport in self.course.lti_passports]
-            if self.lti_id not in lti_passport_ids:
+            lti_passport_ids = [lti_passport.split(':')[0].strip() for lti_passport in self.course.lti_passports]
+            if self.lti_id.strip() not in lti_passport_ids:
                 validation.add(ValidationMessage(ValidationMessage.WARNING, str(
                     _("The specified LTI ID is not configured in this course's Advanced Settings.")
                 )))

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -683,6 +683,24 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         elif data.lti_1p3_tool_key_mode == 'public_key':
             data.lti_1p3_tool_keyset_url = ''
 
+    def validate(self):
+        """
+        Validate this XBlock's configuration
+        """
+        validation = super().validate()
+        _ = self.runtime.service(self, "i18n").ugettext
+        # Check if lti_id exists in the LTI passports of the current course. (LTI 1.1 only)
+        # This validation is just for the Unit page in Studio; we don't want to block users from saving
+        # a new LTI ID before they've added it to advanced settings, but we do want to warn them about it.
+        # If we put this check in validate_field_data(), the settings editor wouldn't let them save changes.
+        if self.lti_version == "lti_1p1" and self.lti_id:
+            lti_passport_ids = [lti_passport.split(':')[0] for lti_passport in self.course.lti_passports]
+            if self.lti_id not in lti_passport_ids:
+                validation.add(ValidationMessage(ValidationMessage.WARNING, str(
+                    _("The specified LTI ID is not configured in this course's Advanced Settings.")
+                )))
+        return validation
+
     def get_settings(self):
         """
         Get the XBlock settings bucket via the SettingsService.

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -146,6 +146,21 @@ class TestProperties(TestLtiConsumerXBlock):
         validation = self.xblock.validate()
         self.assertFalse(validation.empty)
 
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    def test_validate_lti_id(self, mock_course):
+        """
+        Test `lti_id` returns a warning if it's not set as an LTI passport in the course
+        """
+        valid_provider = 'lti_provider'
+        self.xblock.lti_id = valid_provider
+        type(mock_course).lti_passports = PropertyMock(return_value=[f"{valid_provider}:key:secret"])
+        validation = self.xblock.validate()
+        self.assertTrue(validation.empty)
+        # Now set lti_id to something invalid:
+        self.xblock.lti_id = "nonexistent"
+        validation = self.xblock.validate()
+        self.assertFalse(validation.empty)
+
     def test_role(self):
         """
         Test `role` returns the correct LTI role string


### PR DESCRIPTION
This adds a new warning in Studio for LTI 1.1/1.2 consumer components if the specified `lti_id` is not valid for the current course. It doesn't block you from setting an invalid ID, in case you're setting the ID first in the XBlock, then later in Advanced Settings.

![Screenshot 2023-05-31 at 8 44 04 PM](https://github.com/openedx/xblock-lti-consumer/assets/945577/f10936be-af00-4db7-ac8a-abd5416f14b9)

Private-ref: MNG-3638