### PR TITLE
POC for course tool launch

### DIFF
--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -885,8 +885,13 @@ class LtiProctoringConsumer(LtiConsumer1p3):
                 self.set_extra_claim(self.get_assessment_control_claim())
         elif launch_data.message_type == "LtiEndAssessment":
             proctoring_claims = self.get_end_assessment_claims()
+        elif launch_data.message_type == "LtiResourceLinkRequest":
+            proctoring_claims = {}
         else:
-            raise ValueError('lti_message_hint must \"LtiStartProctoring\" or \"LtiEndAssessment\".')
+            raise ValueError(
+                'lti_message_hint must be \"LtiStartProctoring\" or \"LtiEndAssessment\"'
+                'or \"LtiResourceLinkRequest\"'
+            )
 
         self.set_extra_claim(proctoring_claims)
 

--- a/lti_consumer/plugin/urls.py
+++ b/lti_consumer/plugin/urls.py
@@ -11,7 +11,8 @@ from lti_consumer.plugin.views import (LtiAgsLineItemViewset,  # LTI Advantage U
                                        LtiNrpsContextMembershipViewSet, access_token_endpoint,
                                        deep_linking_content_endpoint, deep_linking_response_endpoint,
                                        launch_gate_endpoint, public_keyset_endpoint,
-                                       start_proctoring_assessment_endpoint)
+                                       start_proctoring_assessment_endpoint,
+                                       initiate_course_tool_launch_endpoint)
 
 # LTI 1.3 APIs router
 router = routers.SimpleRouter(trailing_slash=False)
@@ -21,6 +22,11 @@ router.register(r'memberships', LtiNrpsContextMembershipViewSet, basename='lti-n
 
 app_name = 'lti_consumer'
 urlpatterns = [
+    re_path(
+        rf'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/resource/{settings.USAGE_ID_PATTERN}/initiate_login',
+        initiate_course_tool_launch_endpoint,
+        name='lti_consumer.initiate_course_tool_launch_endpoint'
+    ),
     path(
         'lti_consumer/v1/public_keysets/<uuid:lti_config_id>',
         public_keyset_endpoint,


### PR DESCRIPTION
This endpoint would expose a view a frontend app could load given an lti configuration id and a course id. Loading the view would kick off a basic 1.3 launch.

This is definitely pretty limited in what we could support without building out further modeling for what a platform wide or course wide configuration might look like. I think the long term solution very likely depends on OpenCrafts pending work around remodeling configurations / placements. Launch by placement id seems like the more correct end state for this, we just don't have placements yet. In the meantime maybe we can build something really limited to support proctoring or other tools that are course or platform wide.