### PR TITLE
feat: ProctoringConsumer basic launch request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.5.4 - 2023-06-28
+------------------
+* Allow basic LtiResourceLink launch for an LtiProctoringConsumer
+
 9.5.3 - 2023-06-09
 ------------------
 * Redirect to exam on same LTI proctoring launch tab once ready to start.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.5.3'
+__version__ = '9.5.4'

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -885,8 +885,13 @@ class LtiProctoringConsumer(LtiConsumer1p3):
                 self.set_extra_claim(self.get_assessment_control_claim())
         elif launch_data.message_type == "LtiEndAssessment":
             proctoring_claims = self.get_end_assessment_claims()
+        elif launch_data.message_type == "LtiResourceLinkRequest":
+            proctoring_claims = {}
         else:
-            raise ValueError('lti_message_hint must \"LtiStartProctoring\" or \"LtiEndAssessment\".')
+            raise ValueError(
+                'lti_message_hint must be \"LtiStartProctoring\" or \"LtiEndAssessment\"'
+                'or \"LtiResourceLinkRequest\"'
+            )
 
         self.set_extra_claim(proctoring_claims)
 

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -1088,6 +1088,19 @@ class TestLtiProctoringConsumer(TestCase):
             self.assertIn(claim, decoded_token_claims)
 
     @patch('lti_consumer.lti_1p3.consumer.get_data_from_cache')
+    def test_generate_basic_launch_request(self, mock_get_data_from_cache):
+        mock_launch_data = self.get_launch_data(message_type="LtiResourceLinkRequest")
+        mock_get_data_from_cache.return_value = mock_launch_data
+
+        self._setup_proctoring()
+        token = self.lti_consumer.generate_launch_request(
+            self.preflight_response,
+        )['id_token']
+
+        # just check token is valid
+        self.lti_consumer.key_handler.validate_and_decode(token)
+
+    @patch('lti_consumer.lti_1p3.consumer.get_data_from_cache')
     def test_enable_assessment_control(self, mock_get_data_from_cache):
         """
         Ensure that the correct claims are included in LTI launch messages with an ACS url set.
@@ -1120,11 +1133,11 @@ class TestLtiProctoringConsumer(TestCase):
     @patch('lti_consumer.lti_1p3.consumer.get_data_from_cache')
     def test_generate_launch_request_invalid_message(self, mock_get_data_from_cache):
         """
-        Ensures that a ValueError is raised if the launch_data.message_type is not LtiStartProctoring or
-        LtiEndAssessment.
+        Ensures that a ValueError is raised if the launch_data.message_type is not LtiStartProctoring,
+        LtiEndAssessment, or LtiResourceLinkRequest.
         """
 
-        mock_launch_data = self.get_launch_data(message_type="LtiResourceLinkRequest")
+        mock_launch_data = self.get_launch_data(message_type="LtiDeepLinkingRequest")
         mock_get_data_from_cache.return_value = mock_launch_data
 
         self._setup_proctoring()


### PR DESCRIPTION
Allows a basic LtiResourceLinkRequest launch to be performed by the proctoring consumer class. Since it's the parent class this made sense to me versus initializing a different consumer type based on the launch message. Which, would also be hard to implement anyway.