### PR TITLE
fix: LTI 1.3 extra claims and custom parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.6.2 - 2023-08-22
+------------------
+* Fix extra claims and custom parameters for LTI 1.3.
+* Add validation to custom_parameters xblock field.
+
 9.6.1 - 2023-06-28
 ------------------
 * Fix CCX LTI configuration compatibility

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.6.1'
+__version__ = '9.6.2'

--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -83,6 +83,7 @@ class Lti1p3LaunchData:
     * proctoring_launch_data (conditionally required): An instance of the Lti1p3ProctoringLaunchData that contains
         data necessary and related to an LTI 1.3 proctoring launch. It is required if the message_type attribute is
         "LtiStartProctoring" or "LtiEndAssessment".
+    * custom_parameters (optional): The custom parameters claim values. It is a dictionary of custom parameters.
     """
     user_id = field()
     user_role = field()
@@ -104,3 +105,4 @@ class Lti1p3LaunchData:
         default=None,
         validator=validators.optional((validators.instance_of(Lti1p3ProctoringLaunchData))),
     )
+    custom_parameters = field(default={})

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -261,6 +261,10 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         # Set LTI Launch URL.
         context.update({'launch_url': preflight_response.get("redirect_uri")})
 
+        # Set LTI custom properties claim.
+        if launch_data.custom_parameters:
+            lti_consumer.set_custom_parameters(launch_data.custom_parameters)
+
         # Modify LTI Launch URL depending on launch type.
         # Deep Linking Launch - Configuration flow launched by
         # course creators to set up content.

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -579,6 +579,46 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
 
+    @patch('lti_consumer.lti_1p3.consumer.LtiConsumer1p3.set_custom_parameters')
+    def test_launch_existing_custom_parameters(self, mock_set_custom_parameters):
+        """
+        Check custom parameters are set if they exist on XBlock configuration.
+        """
+        self.launch_data.custom_parameters = ['test=test']
+        params = {
+            'client_id': self.config.lti_1p3_client_id,
+            'redirect_uri': 'http://tool.example/launch',
+            'state': 'state_test_123',
+            'nonce': 'nonce',
+            'login_hint': self.launch_data.user_id,
+            'lti_message_hint': self.launch_data_key,
+        }
+
+        response = self.client.get(self.url, params)
+
+        self.assertEqual(response.status_code, 200)
+        mock_set_custom_parameters.assert_called_once_with(self.launch_data.custom_parameters)
+
+    @patch('lti_consumer.lti_1p3.consumer.LtiConsumer1p3.set_custom_parameters')
+    def test_launch_non_existing_custom_parameters(self, mock_set_custom_parameters):
+        """
+        Check custom parameters are not set if they don't exist on XBlock configuration.
+        """
+        self.launch_data.custom_parameters = {}
+        params = {
+            'client_id': self.config.lti_1p3_client_id,
+            'redirect_uri': 'http://tool.example/launch',
+            'state': 'state_test_123',
+            'nonce': 'nonce',
+            'login_hint': self.launch_data.user_id,
+            'lti_message_hint': self.launch_data_key,
+        }
+
+        response = self.client.get(self.url, params)
+
+        self.assertEqual(response.status_code, 200)
+        mock_set_custom_parameters.assert_not_called()
+
 
 class TestLti1p3AccessTokenEndpoint(TestCase):
     """

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -15,6 +15,7 @@ from django.test import override_settings
 from django.test.testcases import TestCase
 from django.utils import timezone
 from jwkest.jwk import RSAKey, KEYS
+from xblock.validation import Validation
 
 from lti_consumer.exceptions import LtiError
 
@@ -87,6 +88,7 @@ class TestIndexibility(TestCase):
         )
 
 
+@ddt.ddt
 class TestProperties(TestLtiConsumerXBlock):
     """
     Unit tests for LtiConsumerXBlock properties
@@ -138,13 +140,48 @@ class TestProperties(TestLtiConsumerXBlock):
         """
         self.assertEqual(self.xblock.context_id, str(self.xblock.scope_ids.usage_id.context_key))
 
-    def test_validate(self):
+    @ddt.data(
+        ['x=y'], [' x x = y y '], ['x= '], [' =y'], [' = '],
+        ['x=y', ' x x = y y ', 'x= ', ' =y', ' = '],
+    )
+    def test_validate_with_valid_custom_parameters(self, custom_parameters):
         """
-        Test that if custom_parameters is empty string, a validation error is added
+        Test if all custom_parameters item are valid
         """
-        self.xblock.custom_parameters = ''
+        self.xblock.custom_parameters = custom_parameters
         validation = self.xblock.validate()
-        self.assertFalse(validation.empty)
+        self.assertEqual(validation.messages, [])
+
+    @patch('lti_consumer.lti_xblock.ValidationMessage')
+    @patch.object(Validation, 'add')
+    def test_validate_with_empty_custom_parameters(self, add_mock, mock_validation_message):
+        """
+        Test if custom_parameters is not a list, a validation error is added
+        """
+        mock_validation_message.ERROR.return_value = 'error'
+        self.xblock.custom_parameters = ''
+
+        self.xblock.validate()
+
+        add_mock.assert_called_once_with(
+            mock_validation_message('error', 'Custom Parameters must be a list'),
+        )
+
+    @ddt.data(['x'], ['x='], ['=y'], ['x==y'], ['x', 'x=', '=y', 'x==y'])
+    @patch('lti_consumer.lti_xblock.ValidationMessage')
+    @patch.object(Validation, 'add')
+    def test_validate_with_invalid_custom_parameters(self, custom_parameters, add_mock, mock_validation_message):
+        """
+        Test if a custom_parameters item is not valid, a validation error is added
+        """
+        mock_validation_message.ERROR.return_value = 'error'
+        self.xblock.custom_parameters = custom_parameters
+
+        self.xblock.validate()
+
+        add_mock.assert_called_once_with(
+            mock_validation_message('error', 'Custom Parameters should be strings in "x=y" format.'),
+        )
 
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     def test_validate_lti_id(self, mock_course):
@@ -1643,6 +1680,25 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.addCleanup(self.mock_filter_enabled_patcher.stop)
         self.addCleanup(self.mock_database_config_enabled_patcher.stop)
 
+    @patch.object(LtiConsumerXBlock, 'get_parameter_processors')
+    @patch('lti_consumer.lti_xblock.resolve_custom_parameter_template')
+    def test_get_lti_1p3_custom_parameters(self, mock_resolve_custom_parameter_template, get_parameter_processors_mock):
+        """
+        Test that get_lti_1p3_custom_parameters returns an dictionary of custom parameters
+        """
+        processor_mock = Mock(return_value={'test3': 'test'}, lti_xblock_default_params={})
+        get_parameter_processors_mock.return_value = [processor_mock]
+        mock_resolve_custom_parameter_template.return_value = ''
+        self.xblock.custom_parameters = ['test1=test', 'test2=${test}']
+
+        self.assertDictEqual(
+            self.xblock.get_lti_1p3_custom_parameters(),
+            {'test1': 'test', 'test2': '', 'test3': 'test'},
+        )
+        get_parameter_processors_mock.assert_called_once_with()
+        processor_mock.assert_called_once_with(self.xblock)
+        mock_resolve_custom_parameter_template.assert_called_once_with(self.xblock, '${test}')
+
     @ddt.idata(product([True, False], [True, False], [True, False], [True, False]))
     @ddt.unpack
     def test_get_lti_1p3_launch_data(
@@ -1685,6 +1741,9 @@ class TestLtiConsumer1p3XBlock(TestCase):
         # Mock out get_pii_sharing_enabled to reduce the amount of mocking we have to do.
         self.xblock.get_pii_sharing_enabled = Mock(return_value=pii_sharing_enabled)
 
+        # Mock custom_parameters property.
+        self.xblock.get_lti_1p3_custom_parameters = Mock(return_value={})
+
         launch_data = self.xblock.get_lti_1p3_launch_data()
 
         course_key = str(self.xblock.scope_ids.usage_id.course_key)
@@ -1701,6 +1760,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             "context_type": ["course_offering"],
             "context_title": "context_title",
             "context_label": course_key,
+            'custom_parameters': {},
         }
 
         if pii_sharing_enabled:
@@ -1721,6 +1781,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             launch_data,
             expected_launch_data
         )
+        self.xblock.get_lti_1p3_custom_parameters.assert_called_once_with()
 
     @patch('lti_consumer.plugin.compat.get_course_by_id')
     def test_get_context_title(self, mock_get_course_by_id):


### PR DESCRIPTION
## Description

This PR adds a feature that allows the LTI consumer XBlock to send custom parameters (including dynamic custom parameters) and extra claims to LTI 1.3 launches.

## Type of Change

- [x] Add LtiConsumerXBlock get_lti_1p3_custom_parameters method.
- [x] Modify LtiConsumerXBlock get_lti_1p3_launch_data method.
- [x] Include tests for all added and modified code.

## Testing:

2. Add LTI custom params template setting:

``` 
# Here we set the value to any module and function
# that can be imported and returns a str.
LTI_CUSTOM_PARAM_TEMPLATES = {
    'test_param': 'django.utils.html:escape'
}
```
3. Add a LTI processors to XBLOCK_SETTINGS (Example: https://github.com/appsembler/tahoe-lti).
4. Create a course and add a LTI 1.3 consumer XBlock.
5. Add custom parameters to the XBlock settings.

```
["test=test", "test_param=${test_param}"] 
``` 

6. Enable the "Send extra parameters" setting. 
7. Go to the live course and execute an LTI 1.3 launch.
8. The custom parameters and extra claims should be present on the https://purl.imsglobal.org/spec/lti/claim/custom claim.