### PR TITLE
fix: correct acs actions constant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.5.6 - 2023-07-27
+------------------
+* Fixed ACS actions constant.
+
 9.5.6 - 2023-07-25
 ------------------
 * Added LTI launch error messages to the template returned when these errors occur.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.5.6'
+__version__ = '9.5.7'

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -96,9 +96,9 @@ LTI_PROCTORING_DATA_KEYS = [
 ]
 
 LTI_PROCTORING_ASSESSMENT_CONTROL_ACTIONS = [
-    'pauseRequest',
-    'resumeRequest',
-    'terminateRequest',
+    'pause',
+    'resume',
+    'terminate',
     'update',
-    'flagRequest',
+    'flag',
 ]


### PR DESCRIPTION
Related to https://github.com/edx/edx-exams/pull/154.

JIRA: https://2u-internal.atlassian.net/jira/software/projects/MST/boards/584?selectedIssue=MST-1961
Description

As of now, the ACS endpoint only supports a flag action. We would also like to support terminate as a way for Proctorio to communicate that they have ended an attempt.

Upon receiving a terminate request, the attempt referenced in the request should be moved to a corresponding status, depending on the reason for termination (reason_code) and incident_severity. The reason_code mappings should be clarified with Proctorio, and the incident_severity should be discussed internally to decide what range of values are considered passing.

Reason codes:

user_submission: move attempt to verified or second_review_required

error: move attempt to error

Severity:

we can just use a constant set to 0.25 for this at the moment

terminate with severity > 0.25 will move to second_review_required otherwise verified

Question: Do we want to store the reason code and incident severity in another model (similar to a review)?

work with dev on MST-1992: Return review info to exams-dashboard