### PR TITLE
fix: Custom parameters validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.8.1 - 2023-11-17
+------------------
+* Fix custom_parameters xblock field validation.
+
 9.7.0 - 2023-10-23
 ------------------
 * Added LTI 1.3 reusable configuration compatibility.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.8.0'
+__version__ = '9.8.1'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -106,10 +106,7 @@ LTI_1P1_ROLE_MAP = {
     'instructor': 'Instructor',
 }
 CUSTOM_PARAMETER_SEPARATOR = '='
-# Allow a key-pair key and value to contain any character except "=".
-CUSTOM_PARAMETER_REGEX = re.compile(
-    rf'^([^{CUSTOM_PARAMETER_SEPARATOR}]+{CUSTOM_PARAMETER_SEPARATOR}[^{CUSTOM_PARAMETER_SEPARATOR}]+)$',
-)
+CUSTOM_PARAMETER_REGEX = re.compile(rf'^(.+{CUSTOM_PARAMETER_SEPARATOR}.+)$')
 # Catch a value enclosed by ${}, the value enclosed can contain any charater except "=".
 CUSTOM_PARAMETER_TEMPLATE_REGEX = re.compile(r'^(\${[^%s]+})$' % CUSTOM_PARAMETER_SEPARATOR)
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -141,8 +141,8 @@ class TestProperties(TestLtiConsumerXBlock):
         self.assertEqual(self.xblock.context_id, str(self.xblock.scope_ids.usage_id.context_key))
 
     @ddt.data(
-        ['x=y'], [' x x = y y '], ['x= '], [' =y'], [' = '],
-        ['x=y', ' x x = y y ', 'x= ', ' =y', ' = '],
+        ['x=y'], [' x x = y y '], ['x= '], [' =y'], [' = '], [' x = = y = z '],
+        ['x=y', ' x x = y y ', 'x= ', ' =y', ' = ', ' x = = y = z '],
     )
     def test_validate_with_valid_custom_parameters(self, custom_parameters):
         """
@@ -167,7 +167,7 @@ class TestProperties(TestLtiConsumerXBlock):
             mock_validation_message('error', 'Custom Parameters must be a list'),
         )
 
-    @ddt.data(['x'], ['x='], ['=y'], ['x==y'], ['x', 'x=', '=y', 'x==y'])
+    @ddt.data(['x'], ['x='], ['=y'], ['x', 'x=', '=y'])
     @patch('lti_consumer.lti_xblock.ValidationMessage')
     @patch.object(Validation, 'add')
     def test_validate_with_invalid_custom_parameters(self, custom_parameters, add_mock, mock_validation_message):


### PR DESCRIPTION
## Description

This PR adds a fix to the validation of the LTI consumer XBlock custom parameters field. The previously merged PR https://github.com/openedx/xblock-lti-consumer/pull/392 introduced a bug that broke backwards compatible with custom parameters such has: `["next=something?repo=https://github.com/org/repo?folder=/home/user&branch=main"]`. This issue was raised on https://github.com/openedx/xblock-lti-consumer/issues/410.

## Type of Change

- [x] Modify CUSTOM_PARAMETER_REGEX constant.
- [x] Include tests for all modified code.

## Testing:

1. Create a course and add a LTI consumer XBlock.
2. Add custom parameters to the XBlock settings.

```
["next=something?repo=https://github.com/org/repo?folder=/home/user&branch=main"] 
``` 

3. Go to the live course and execute an LTI launch.
4. The custom parameters should be present on the LTI launch data.