### PR TITLE
feat: additional performance tracing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 
 Unreleased
 ~~~~~~~~~~
+9.8.3 - 2024-01-23
+------------------
+* Additional NewRelic traces to functions suspected of causing performance issues.
+
 9.8.2 - 2024-01-19
 ------------------
 * Add NewRelic traces to functions suspected of causing performance issues.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.8.2'
+__version__ = '9.8.3'

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -34,6 +34,7 @@ class LtiConsumer1p3:
     LTI 1.3 Consumer Implementation
     """
 
+    @function_trace('lti_consumer.lti_1p3.consumer.LtiConsumer1p3.__init__')
     def __init__(
             self,
             iss,

--- a/lti_consumer/lti_1p3/key_handlers.py
+++ b/lti_consumer/lti_1p3/key_handlers.py
@@ -11,6 +11,7 @@ import json
 import logging
 
 from Cryptodome.PublicKey import RSA
+from edx_django_utils.monitoring import function_trace
 from jwkest import BadSignature, BadSyntax, WrongNumberOfParts, jwk
 from jwkest.jwk import RSAKey, load_jwks_from_url
 from jwkest.jws import JWS, NoSuitableSigningKeys, UnknownAlgorithm
@@ -32,6 +33,7 @@ class ToolKeyHandler:
     in order to validate the JWT Signature of messages
     signed with the tools signature.
     """
+    @function_trace('lti_consumer.key_handlers.ToolKeyHandler.__init__')
     def __init__(self, public_key=None, keyset_url=None):
         """
         Instance message validator
@@ -162,6 +164,7 @@ class PlatformKeyHandler:
     This class loads the platform key and is responsible for
     encoding JWT messages and exporting public keys.
     """
+    @function_trace('lti_consumer.key_handlers.PlatformKeyHandler.__init__')
     def __init__(self, key_pem, kid=None):
         """
         Import Key when instancing class if a key is present.


### PR DESCRIPTION
We're spending over a second initializing the consumer object which slows down every endpoint. If that's our issue it seems like loading these keys is the only potential cause in that code path. Logging each step to confirm.