### PR TITLE
[LET-108] Fix check Deep linking Response type

### DIFF
--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -716,7 +716,7 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
         # Check the response is a Deep Linking response type
         message_type = deep_link_response.get("https://purl.imsglobal.org/spec/lti/claim/message_type")
-        if not message_type == "LtiDeepLinkingResponse":
+        if not (isinstance(message_type, str) and message_type.lower() == "ltideeplinkingresponse"):
             raise exceptions.InvalidClaimValue("Token isn't a Deep Linking Response message.")
 
         # Check if supported contentitems were returned


### PR DESCRIPTION
Related Jira Ticket: [LET-108](https://correlation-one.atlassian.net/browse/LET-108)

Description: Bugfix to correctly check the deep linking response from Codio.

It ignores the case of the `https://purl.imsglobal.org/spec/lti/claim/message_type` value present on the JWT token.