### PR TITLE
feat: add i18n_js_namespace to support atlas - FC-0012

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 
 Unreleased
 ~~~~~~~~~~
+9.9.0 (2024-01-24)
+---------------------------
+* XBlockI18NService js translations support
+
 9.8.3 - 2024-01-23
 ------------------
 * Additional NewRelic traces to functions suspected of causing performance issues.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.8.3'
+__version__ = '9.9.0'

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -31,6 +31,14 @@ def _(text):
     return text
 
 
+def ngettext_fallback(text_singular, text_plural, number):
+    """ Dummy `ngettext` replacement to make string extraction tools scrape strings marked for translation """
+    if number == 1:
+        return text_singular
+    else:
+        return text_plural
+
+
 def get_lti_api_base():
     """
     Returns base url to be used as issuer on OAuth2 flows
@@ -361,3 +369,11 @@ def model_to_dict(model_object, exclude=None):
         return object_fields
     except (AttributeError, TypeError):
         return {}
+
+
+class DummyTranslationService:
+    """
+    Dummy drop-in replacement for i18n XBlock service
+    """
+    gettext = _
+    ngettext = ngettext_fallback


### PR DESCRIPTION
Implement OEP-58 JavaScript translations
---

Details:
* Proposal: https://github.com/openedx/edx-platform/pull/33166
* Supporting platform pull request: https://github.com/openedx/edx-platform/pull/33698
* Similar pull request: https://github.com/openedx/xblock-drag-and-drop-v2/pull/365

Testing
---

Local tutor 17.0.2
- [x] translations are still working including JS translations. I added a temporary console log and it showed the translation correctly (to avoid the hustle connecting a real LTI)
`console.log(gettext('LTI Consumer'))`
![Screenshot from 2024-02-28 11-58-10](https://github.com/openedx/xblock-lti-consumer/assets/17448993/30faef7d-0d0b-4229-a1d0-37df4f75da8e)
 
References
---

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).