### PR TITLE
fix: set height of lti modal to 100% not auto

### DIFF
--- a/lti_consumer/static/sass/student.scss
+++ b/lti_consumer/static/sass/student.scss
@@ -114,7 +114,7 @@
             z-index: 11000;
             box-sizing: border-box;
             margin-left: 0;
-            height: auto;
+            height: 100%;
             padding: 8px;
             border-radius: 3px;
             box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
TICKET: https://2u-internal.atlassian.net/browse/COSMO-227

It seems the css for the height of an LTI modal's iframe was set to "auto" (which seemed to be defaulting to 100vh), not 100%, which seems to have caused issues for some learners on iPads.

NOTE: I have yet to test this locally and I'm not sure I can, especially given that we can't use the IMS global to anymore.