### PR TITLE
fix: add utf-8 encoding for user fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,13 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.11.1 - 2024-04-24
+-------------------
+* Add utf-8 encoding for user full name
+
 9.11.0 - 2024-04-24
 -------------------
 * Remove lxml pin
-
 
 9.10.0 - 2024-02-29
 ------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.11.0'
+__version__ = '9.11.1'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1130,7 +1130,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         user_data = {
             'user_email': None,
             'user_username': None,
-            'user_full_name': user.full_name,
+            'user_full_name': user.full_name.encode(),
             'user_language': None,
         }
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -957,7 +957,8 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
         fake_user_email = 'abc@example.com'
         fake_user.emails = [fake_user_email]
 
-        full_name_mock = PropertyMock(return_value='fake_full_name')
+        fake_name = 'fáke fǔll ñamë'
+        full_name_mock = PropertyMock(return_value=fake_name)
         type(fake_user).full_name = full_name_mock
 
         fake_username = 'fake'
@@ -1077,7 +1078,7 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
 
         set_user_data_kwargs['person_sourcedid'] = 'fake' if pii_sharing_enabled and ask_to_send_username else None
         set_user_data_kwargs['person_name_full'] = (
-            'fake_full_name' if pii_sharing_enabled and ask_to_send_full_name else None
+            'fáke fǔll ñamë'.encode() if pii_sharing_enabled and ask_to_send_full_name else None
         )
         set_user_data_kwargs['person_contact_email_primary'] = (
             'abc@example.com' if pii_sharing_enabled and ask_to_send_email else None
@@ -1814,7 +1815,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
         fake_user_email = 'fake_email@example.com'
         fake_username = 'fake_username'
 
-        fake_name = 'fake_full_name'
+        fake_name = 'fáke fǔll ñamë'
         full_name_mock = PropertyMock(return_value=fake_name)
         type(fake_user).full_name = full_name_mock
 
@@ -1866,7 +1867,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
                 expected_launch_data_kwargs["preferred_username"] = fake_username
 
             if ask_to_send_full_name:
-                expected_launch_data_kwargs["name"] = fake_name
+                expected_launch_data_kwargs["name"] = fake_name.encode()
 
             if ask_to_send_email:
                 expected_launch_data_kwargs["email"] = fake_user_email


### PR DESCRIPTION
## [COSMO-276](https://2u-internal.atlassian.net/browse/COSMO-276)

Users with accents in their names are unable to use certain LTI tools because we do not send a utf-8 encoded version of their name to the LTI tool. 

This change encodes a user's full name, which is then used in the LTI launch.