### PR TITLE
feat: update python version for pypi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pip
         run: pip install -r requirements/pip.txt


### PR DESCRIPTION
It looks like the python version for the pypi publish workflow has been updated for other repos (see https://github.com/openedx/edx-proctoring/pull/1210). 

The publish step is currently not working for xblock-lti-consumer, so checking if this works.