### PR TITLE
fix: remove utf-8 encoding for full name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.11.3 - 2024-05-30
+-------------------
+* Remove utf-8 encoding for user full name
+
 9.11.2 - 2024-05-30
 -------------------
 * Update python version for pypi publish workflow

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.11.2'
+__version__ = '9.11.3'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1130,7 +1130,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         user_data = {
             'user_email': None,
             'user_username': None,
-            'user_full_name': user.full_name.encode(),
+            'user_full_name': user.full_name,
             'user_language': None,
         }
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1078,7 +1078,7 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
 
         set_user_data_kwargs['person_sourcedid'] = 'fake' if pii_sharing_enabled and ask_to_send_username else None
         set_user_data_kwargs['person_name_full'] = (
-            'fáke fǔll ñamë'.encode() if pii_sharing_enabled and ask_to_send_full_name else None
+            'fáke fǔll ñamë' if pii_sharing_enabled and ask_to_send_full_name else None
         )
         set_user_data_kwargs['person_contact_email_primary'] = (
             'abc@example.com' if pii_sharing_enabled and ask_to_send_email else None
@@ -1867,7 +1867,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
                 expected_launch_data_kwargs["preferred_username"] = fake_username
 
             if ask_to_send_full_name:
-                expected_launch_data_kwargs["name"] = fake_name.encode()
+                expected_launch_data_kwargs["name"] = fake_name
 
             if ask_to_send_email:
                 expected_launch_data_kwargs["email"] = fake_user_email


### PR DESCRIPTION
Related to [COSMO-276](https://2u-internal.atlassian.net/browse/COSMO-276).

A user's name is already utf-8 encoded as part of the HTML form used in the LTI launch handler. 