### PR TITLE
docs: update saltire LTI URL for testing LTI 1.1/1.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,11 @@ http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/lat
    as seen above).  Make a unit, select "Advanced", then "LTI Consumer".
 3. Click edit and fill in the following fields:
    ``LTI ID``: "test"
-   ``LTI URL``: "https://lti.tools/saltire/tp"
+   ``LTI URL``: "https://saltire.lti.app/tool"
+   **Note:** If you are using more than one same LTI xblocks in the same unit, 
+   please append the `norefresh` parameter to the LTI URL to avoid any 
+   potential failures. Then LTI URL will look like this: 
+   `https://saltire.lti.app/tool?norefresh`.
 4. Click save.  The unit should refresh and you should see "Passed" in the "Verification" field of
    the message tab in the LTI Tool Provider emulator.
 5. Click the "Publish" button.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.12.0'
+__version__ = '9.12.1'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -646,7 +646,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                         ask_to_send_email="False"
                         enable_processors="True"
                         launch_target="new_window"
-                        launch_url="https://lti.tools/saltire/tp" />
+                        launch_url="https://saltire.lti.app/tool?norefresh" />
 
                     <lti_consumer
                         display_name="LTI Consumer - IFrame"
@@ -656,7 +656,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                         enable_processors="True"
                         description=""
                         launch_target="iframe"
-                        launch_url="https://lti.tools/saltire/tp" />
+                        launch_url="https://saltire.lti.app/tool?norefresh" />
                 </sequence_demo>
              '''),
         ]


### PR DESCRIPTION
- update lti testing url in the README, as saltire has updated the test URLs.
- add a note in the README to use `norefresh` param, to avoid failures if using more than one same LTI xblocks in the same unit. Details can be viewed here: https://github.com/openedx/xblock-lti-consumer/issues/379
- close #379.