### PR TITLE
fix: ensure that LTI 1.3 launches work

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.13.1 - 2025-01-15
+-------------------
+* Fix broken LTI 1.3 launch
+
 9.13.0 - 2025-01-08
 -------------------
 * Removed pyjwkset package and replace with pyjwt package

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 
 9.13.1 - 2025-01-15
 -------------------
-* Fix broken LTI 1.3 launch
+* Fix broken LTI 1.3 launch by adding a `kid` field to both the JWT header and data returned by the public keyset endpoint.
 
 9.13.0 - 2025-01-08
 -------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.13.0'
+__version__ = '9.13.1'

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -122,6 +122,7 @@ class TestLti1p3Consumer(TestCase):
         keyset = PyJWKSet.from_dict(public_keyset).keys
 
         for obj in keyset:
+            self.assertEqual(obj.key_id, RSA_KEY_ID)
             message = jwt.decode(
                 token,
                 key=obj.key,

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -479,7 +479,6 @@ def access_token_endpoint(
     except Exception:  # pylint: disable=broad-except
         exc_info = sys.exc_info()
 
-        # import pdb; pdb.set_trace()
         # Handle errors and return a proper response
         if exc_info[0] == MissingRequiredClaim:
             # Missing request attributes

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -1,8 +1,9 @@
 # Requirements for Quality runs
 -c constraints.txt
 
--r base.txt 
+-r base.txt
 
+cryptography
 pycodestyle
 pylint
 edx_lint

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -61,6 +61,8 @@ code-annotations==2.1.0
     # via edx-lint
 cookiecutter==2.6.0
     # via xblock-sdk
+cryptography==44.0.0
+    # via -r requirements/quality.in
 ddt==1.7.2
     # via -r requirements/quality.in
 dill==0.3.9

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,6 +4,7 @@
 -r base.txt               # Core dependencies for the cookiecutter
 
 coveralls
+cryptography
 ddt
 djangorestframework
 edx_lint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -69,7 +69,7 @@ coverage[toml]==7.6.9
 coveralls==4.0.1
     # via -r requirements/test.in
 cryptography==44.0.0
-    # via secretstorage
+    # via -r requirements/test.in
 ddt==1.7.2
     # via -r requirements/test.in
 dill==0.3.9


### PR DESCRIPTION
## [COSMO-629](https://2u-internal.atlassian.net/browse/COSMO-629)

Changes introduced in v9.13.0 caused LTI 1.3 launches to not function. This was because the `kid` field was missing from both the JWT header sent to the tool, and from the public keyset endpoint. 

This PR adds the `kid` to the JWT header and ensures that the `kid` is also available in the public keyset endpoint. I've also removed some `pyjwkest` related code that is no longer needed.