### PR TITLE
chore: Upgrade Python requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.13.4 - 2025-03-21
+-------------------
+* fix: update tests after pyjwt version upgrade
+
 9.13.3 - 2025-03-12
 -------------------
 * Allows LTI Consumer blocks to be used in Libraries v2 learning context

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.13.3'
+__version__ = '9.13.4'

--- a/lti_consumer/lti_1p3/key_handlers.py
+++ b/lti_consumer/lti_1p3/key_handlers.py
@@ -55,7 +55,7 @@ class ToolKeyHandler:
                 public_key = algo_obj.prepare_key(public_key)
                 public_jwk = json.loads(algo_obj.to_jwk(public_key))
                 self.public_key = PyJWK.from_dict(public_jwk)
-            except ValueError as err:
+            except jwt.exceptions.InvalidKeyError as err:
                 log.warning(
                     'An error was encountered while loading the LTI tool\'s key from the public key. '
                     'The RSA key could not parsed.'
@@ -148,7 +148,7 @@ class PlatformKeyHandler:
                 private_jwk = json.loads(algo.to_jwk(private_key))
                 private_jwk['kid'] = kid
                 self.key = PyJWK.from_dict(private_jwk)
-            except ValueError as err:
+            except jwt.exceptions.InvalidKeyError as err:
                 log.warning(
                     'An error was encountered while loading the LTI platform\'s key. '
                     'The RSA key could not be loaded.'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,25 +8,25 @@ appdirs==1.4.4
     # via fs
 asgiref==3.8.1
     # via django
-attrs==24.3.0
+attrs==25.1.0
     # via -r requirements/base.in
 bleach==6.2.0
     # via -r requirements/base.in
-boto3==1.35.82
+boto3==1.36.17
     # via fs-s3fs
-botocore==1.35.82
+botocore==1.36.17
     # via
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via edx-django-utils
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -65,6 +65,7 @@ edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
+    #   openedx-filters
 fs==2.4.16
     # via
     #   fs-s3fs
@@ -84,11 +85,11 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 lazy==1.6
     # via -r requirements/base.in
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/base.in
     #   xblock
-mako==1.3.8
+mako==1.3.9
     # via
     #   -r requirements/base.in
     #   xblock
@@ -96,17 +97,17 @@ markupsafe==3.0.2
     # via
     #   mako
     #   xblock
-newrelic==10.4.0
+newrelic==10.6.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.in
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.in
-openedx-filters==1.12.0
+openedx-filters==1.13.0
     # via -r requirements/base.in
-pbr==6.1.0
+pbr==6.1.1
     # via stevedore
-psutil==6.1.0
+psutil==6.1.1
     # via edx-django-utils
 pycparser==2.22
     # via cffi
@@ -116,9 +117,9 @@ pycryptodomex==3.21.0
     #   pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/base.in
-pyjwt==2.6.0
+pyjwt==2.10.1
     # via -r requirements/base.in
-pymongo==4.10.1
+pymongo==4.11.1
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -126,13 +127,13 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   xblock
-pytz==2024.2
+pytz==2025.1
     # via xblock
 pyyaml==6.0.2
     # via xblock
 requests==2.32.3
     # via pyjwkest
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via boto3
 simplejson==3.19.3
     # via xblock
@@ -153,6 +154,7 @@ typing-extensions==4.12.2
     # via edx-opaque-keys
 urllib3==1.26.20
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   botocore
     #   requests
@@ -162,7 +164,7 @@ webencodings==0.5.1
     # via bleach
 webob==1.8.9
     # via xblock
-xblock==5.1.0
+xblock==5.1.2
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -16,12 +16,12 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.6
+astroid==3.3.8
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==24.3.0
+attrs==25.1.0
     # via -r requirements/test.txt
 backports-tarfile==1.2.0
     # via
@@ -33,20 +33,20 @@ binaryornot==0.4.4
     #   cookiecutter
 bleach==6.2.0
     # via -r requirements/test.txt
-boto3==1.35.82
+boto3==1.36.17
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.35.82
+botocore==1.36.17
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -r requirements/tox.txt
     #   tox
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements/test.txt
     #   requests
@@ -61,11 +61,11 @@ chardet==5.2.0
     #   -r requirements/tox.txt
     #   binaryornot
     #   tox
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -77,7 +77,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==2.1.0
+code-annotations==2.2.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -89,7 +89,7 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.6.9
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   coveralls
@@ -109,7 +109,7 @@ distlib==0.3.9
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -165,13 +165,14 @@ edx-django-utils==7.1.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
-edx-lint==5.4.1
+edx-lint==5.6.0
     # via -r requirements/test.txt
 edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
-filelock==3.16.1
+    #   openedx-filters
+filelock==3.17.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -191,15 +192,19 @@ future==1.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
+id==1.5.0
+    # via
+    #   -r requirements/test.txt
+    #   twine
 idna==3.10
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -r requirements/test.txt
     #   keyring
-isort==5.13.2
+isort==6.0.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -220,7 +225,7 @@ jeepney==0.8.0
     #   -r requirements/test.txt
     #   keyring
     #   secretstorage
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -232,18 +237,18 @@ jmespath==1.0.1
     #   botocore
 jsonfield==3.1.0
     # via -r requirements/test.txt
-keyring==25.5.0
+keyring==25.6.0
     # via
     #   -r requirements/test.txt
     #   twine
 lazy==1.6
     # via -r requirements/test.txt
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.8
+mako==1.3.9
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -267,12 +272,12 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.1.0
     # via -r requirements/test.txt
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.4.0
+newrelic==10.6.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -284,7 +289,7 @@ oauthlib==3.2.2
     # via -r requirements/test.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/test.txt
-openedx-filters==1.12.0
+openedx-filters==1.13.0
     # via -r requirements/test.txt
 packaging==24.2
     # via
@@ -293,14 +298,10 @@ packaging==24.2
     #   pyproject-api
     #   tox
     #   twine
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.12.0
-    # via
-    #   -r requirements/test.txt
-    #   twine
 platformdirs==4.3.6
     # via
     #   -r requirements/test.txt
@@ -312,7 +313,7 @@ pluggy==1.5.0
     # via
     #   -r requirements/tox.txt
     #   tox
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -326,16 +327,16 @@ pycryptodomex==3.21.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -r requirements/test.txt
     #   readme-renderer
     #   rich
 pyjwkest==1.4.2
     # via -r requirements/test.txt
-pyjwt==2.6.0
+pyjwt==2.10.1
     # via -r requirements/test.txt
-pylint==3.3.2
+pylint==3.3.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -355,7 +356,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.10.1
+pymongo==4.11.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -367,7 +368,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -382,7 +383,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2024.2
+pytz==2025.1
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -401,6 +402,7 @@ requests==2.32.3
     #   -r requirements/test.txt
     #   cookiecutter
     #   coveralls
+    #   id
     #   pyjwkest
     #   requests-toolbelt
     #   twine
@@ -418,7 +420,7 @@ rich==13.9.4
     #   -r requirements/test.txt
     #   cookiecutter
     #   twine
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -458,9 +460,9 @@ tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.23.2
+tox==4.24.1
     # via -r requirements/tox.txt
-twine==6.0.1
+twine==6.1.0
     # via -r requirements/test.txt
 types-python-dateutil==2.9.0.20241206
     # via
@@ -472,12 +474,13 @@ typing-extensions==4.12.2
     #   edx-opaque-keys
 urllib3==1.26.20
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests
     #   twine
-virtualenv==20.28.0
+virtualenv==20.29.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -495,7 +498,7 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.0
+xblock==5.1.2
     # via
     #   -r requirements/test.txt
     #   xblock-sdk

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -25,3 +25,7 @@ django-simple-history==3.0.0
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
+
+# Cause: https://github.com/openedx/edx-lint/issues/475
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
+urllib3<2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,20 +12,20 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==24.3.0
+attrs==25.1.0
     # via -r requirements/base.txt
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.35.82
+boto3==1.36.17
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.35.82
+botocore==1.36.17
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements/base.txt
     #   requests
@@ -33,15 +33,15 @@ cffi==1.17.1
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django==4.2.17
+django==4.2.19
     # via
     #   -r requirements/base.txt
     #   django-appconf
@@ -94,6 +94,7 @@ edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-filters
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -121,7 +122,7 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 lazy==1.6
     # via -r requirements/base.txt
-lxml[html-clean]==5.3.0
+lxml[html-clean]==5.3.1
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
@@ -129,7 +130,7 @@ lxml[html-clean]==5.3.0
     #   xblock
 lxml-html-clean==0.4.1
     # via lxml
-mako==1.3.8
+mako==1.3.9
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -138,7 +139,7 @@ markupsafe==3.0.2
     #   -r requirements/base.txt
     #   mako
     #   xblock
-newrelic==10.4.0
+newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -146,17 +147,17 @@ oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.12.0
+openedx-filters==1.13.0
     # via -r requirements/base.txt
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
 polib==1.2.0
     # via edx-i18n-tools
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -170,9 +171,9 @@ pycryptodomex==3.21.0
     #   pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/base.txt
-pyjwt==2.6.0
+pyjwt==2.10.1
     # via -r requirements/base.txt
-pymongo==4.10.1
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -185,7 +186,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   botocore
     #   xblock
-pytz==2024.2
+pytz==2025.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -198,7 +199,7 @@ requests==2.32.3
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -244,7 +245,7 @@ webob==1.8.9
     # via
     #   -r requirements/base.txt
     #   xblock
-xblock==5.1.0
+xblock==5.1.2
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c /home/runner/work/xblock-lti-consumer/xblock-lti-consumer/requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.6.0
+setuptools==75.8.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.1.7
+click==8.1.8
     # via pip-tools
 packaging==24.2
     # via build

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,40 +14,41 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.6
+astroid==3.3.8
     # via
     #   pylint
     #   pylint-celery
-attrs==24.3.0
+attrs==25.1.0
     # via -r requirements/base.txt
 binaryornot==0.4.4
     # via cookiecutter
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.35.82
+boto3==1.36.17
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.35.82
+botocore==1.36.17
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
     #   -r requirements/base.txt
+    #   cryptography
     #   pynacl
 chardet==5.2.0
     # via binaryornot
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/base.txt
     #   click-log
@@ -57,7 +58,7 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.1.0
+code-annotations==2.2.0
     # via edx-lint
 cookiecutter==2.6.0
     # via xblock-sdk
@@ -67,7 +68,7 @@ ddt==1.7.2
     # via -r requirements/quality.in
 dill==0.3.9
     # via pylint
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -115,12 +116,13 @@ edx-django-utils==7.1.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
-edx-lint==5.4.1
+edx-lint==5.6.0
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-filters
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -140,9 +142,9 @@ idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
-isort==5.13.2
+isort==6.0.0
     # via pylint
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   code-annotations
     #   cookiecutter
@@ -155,12 +157,12 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 lazy==1.6
     # via -r requirements/base.txt
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.8
+mako==1.3.9
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -176,7 +178,7 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-newrelic==10.4.0
+newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -184,15 +186,15 @@ oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.12.0
+openedx-filters==1.13.0
     # via -r requirements/base.txt
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
 platformdirs==4.3.6
     # via pylint
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -206,13 +208,13 @@ pycryptodomex==3.21.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-pygments==2.18.0
+pygments==2.19.1
     # via rich
 pyjwkest==1.4.2
     # via -r requirements/base.txt
-pyjwt==2.6.0
+pyjwt==2.10.1
     # via -r requirements/base.txt
-pylint==3.3.2
+pylint==3.3.4
     # via
     #   -r requirements/quality.in
     #   edx-lint
@@ -227,7 +229,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.10.1
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -247,7 +249,7 @@ python-slugify==8.0.4
     # via
     #   code-annotations
     #   cookiecutter
-pytz==2024.2
+pytz==2025.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -265,7 +267,7 @@ requests==2.32.3
     #   xblock-sdk
 rich==13.9.4
     # via cookiecutter
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -305,6 +307,7 @@ typing-extensions==4.12.2
     #   edx-opaque-keys
 urllib3==1.26.20
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   botocore
@@ -323,7 +326,7 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.0
+xblock==5.1.2
     # via
     #   -r requirements/base.txt
     #   xblock-sdk

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,11 +14,11 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.6
+astroid==3.3.8
     # via
     #   pylint
     #   pylint-celery
-attrs==24.3.0
+attrs==25.1.0
     # via -r requirements/base.txt
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -26,16 +26,16 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.35.82
+boto3==1.36.17
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.35.82
+botocore==1.36.17
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements/base.txt
     #   requests
@@ -46,11 +46,11 @@ cffi==1.17.1
     #   pynacl
 chardet==5.2.0
     # via binaryornot
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/base.txt
     #   click-log
@@ -60,21 +60,23 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.1.0
+code-annotations==2.2.0
     # via edx-lint
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.6.9
+coverage[toml]==7.6.12
     # via coveralls
 coveralls==4.0.1
     # via -r requirements/test.in
 cryptography==44.0.0
-    # via -r requirements/test.in
+    # via
+    #   -r requirements/test.in
+    #   secretstorage
 ddt==1.7.2
     # via -r requirements/test.in
 dill==0.3.9
     # via pylint
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -127,12 +129,13 @@ edx-django-utils==7.1.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
-edx-lint==5.4.1
+edx-lint==5.6.0
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.11.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
+    #   openedx-filters
 fs==2.4.16
     # via
     #   -r requirements/base.txt
@@ -148,13 +151,15 @@ future==1.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
+id==1.5.0
+    # via twine
 idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via keyring
-isort==5.13.2
+isort==6.0.0
     # via pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -166,7 +171,7 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   code-annotations
     #   cookiecutter
@@ -177,16 +182,16 @@ jmespath==1.0.1
     #   botocore
 jsonfield==3.1.0
     # via -r requirements/base.txt
-keyring==25.5.0
+keyring==25.6.0
     # via twine
 lazy==1.6
     # via -r requirements/base.txt
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.8
+mako==1.3.9
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -204,11 +209,11 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.1.0
     # via -r requirements/test.in
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.4.0
+newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -218,19 +223,17 @@ oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.12.0
+openedx-filters==1.13.0
     # via -r requirements/base.txt
 packaging==24.2
     # via twine
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-pkginfo==1.12.0
-    # via twine
 platformdirs==4.3.6
     # via pylint
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -244,15 +247,15 @@ pycryptodomex==3.21.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
 pyjwkest==1.4.2
     # via -r requirements/base.txt
-pyjwt==2.6.0
+pyjwt==2.10.1
     # via -r requirements/base.txt
-pylint==3.3.2
+pylint==3.3.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -266,7 +269,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.10.1
+pymongo==4.11.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -286,7 +289,7 @@ python-slugify==8.0.4
     # via
     #   code-annotations
     #   cookiecutter
-pytz==2024.2
+pytz==2025.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -305,6 +308,7 @@ requests==2.32.3
     #   -r requirements/base.txt
     #   cookiecutter
     #   coveralls
+    #   id
     #   pyjwkest
     #   requests-toolbelt
     #   twine
@@ -317,7 +321,7 @@ rich==13.9.4
     # via
     #   cookiecutter
     #   twine
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -351,7 +355,7 @@ text-unidecode==1.3
     # via python-slugify
 tomlkit==0.13.2
     # via pylint
-twine==6.0.1
+twine==6.1.0
     # via -r requirements/test.in
 types-python-dateutil==2.9.0.20241206
     # via arrow
@@ -361,6 +365,7 @@ typing-extensions==4.12.2
     #   edx-opaque-keys
 urllib3==1.26.20
     # via
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   botocore
@@ -380,7 +385,7 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.0
+xblock==5.1.2
     # via
     #   -r requirements/base.txt
     #   xblock-sdk

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.0
+cachetools==5.5.1
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   tox
     #   virtualenv
@@ -26,9 +26,9 @@ platformdirs==4.3.6
     #   virtualenv
 pluggy==1.5.0
     # via tox
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via tox
-tox==4.23.2
+tox==4.24.1
     # via -r requirements/tox.in
-virtualenv==20.28.0
+virtualenv==20.29.2
     # via tox


### PR DESCRIPTION
This PR upgrade python requirements and fixes code([failures](https://github.com/openedx/xblock-lti-consumer/actions/runs/13266356476/job/37034706505?pr=531)) after upgrading `pyjwt` from `2.6.0` to `2.10.1`.
