### PR TITLE
 Allow lti_consumer blocks to be used in Libraries v2 context [FC-0076] 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.13.3 - 2025-03-12
+-------------------
+* Allows LTI Consumer blocks to be used in Libraries v2 learning context
+
 9.13.2 - 2025-01-21
 -------------------
 * Fix Data too long for column 'resource_id'. Increase column size to 255.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.13.2'
+__version__ = '9.13.3'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1246,9 +1246,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         context = context or {}
         context.update(self._get_context_for_template())
 
-        # Prepend the author view for LTI1.3 when rendering student view to staff users
+        # Prepend the author view for LTI1.3 when rendering student view to staff users in Studio.
         # This is needed so course staff can see the author view parameters when configuring within Libraries v2
-        if self.lti_version == "lti_1p3" and self.user_is_staff:
+        if settings.SERVICE_VARIANT != 'lms' and self.lti_version == "lti_1p3" and self.user_is_staff:
             self._add_author_view(context, loader, fragment)
 
         fragment.add_content(loader.render_mako_template('/templates/html/student.html', context))

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1076,7 +1076,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         custom_parameters['custom_component_display_name'] = str(self.display_name)
 
-        if self.due:
+        if getattr(self, 'due', None):
             custom_parameters.update({
                 'custom_component_due_date': self.due.strftime('%Y-%m-%d %H:%M:%S')
             })
@@ -1218,6 +1218,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         fragment = Fragment()
         loader = ResourceLoader(__name__)
+        context = context or {}
         context.update(self._get_context_for_template())
         fragment.add_content(loader.render_mako_template('/templates/html/student.html', context))
         fragment.add_css(loader.load_unicode('static/css/student.css'))
@@ -1734,7 +1735,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'launch_url': launch_url.strip(),
             'lti_1p3_launch_url': lti_1p3_launch_url,
             'element_id': self.scope_ids.usage_id.html_id(),
-            'element_class': self.category,
+            'element_class': getattr(self, 'category', ''),
             'launch_target': self.launch_target,
             'display_name': self.display_name,
             'form_url': lti_block_launch_handler,

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -91,9 +91,10 @@ def load_enough_xblock(location):  # pragma: nocover
     from xmodule.modulestore.django import modulestore
     from openedx.core.djangoapps.xblock import api as xblock_api
 
-    # Retrieve block from modulestore
+    # Retrieve course block from modulestore
     if isinstance(location.context_key, CourseKey):
         return modulestore().get_item(location)
+    # Retrieve library block from the XBlock API
     else:
         return xblock_api.load_block(location, None)
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -227,17 +227,11 @@ def get_course_by_id(course_key):  # pragma: nocover
     """
     Import and run `get_course_by_id` from LMS
 
-    TODO: Once the LMS has fully switched over to this new path [1],
-    we can remove the legacy (LMS) import support here.
-
-    - [1] https://github.com/openedx/edx-platform/pull/27289
+    Returns None if the provided key is not a CourseKey,
+    e.g the block is used in a library learning context.
     """
-    # pylint: disable=import-outside-toplevel
-    try:
-        from openedx.core.lib.courses import get_course_by_id as lms_get_course_by_id
-    except ImportError:
-        from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
-
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.lib.courses import get_course_by_id as lms_get_course_by_id
     if isinstance(course_key, CourseKey):
         return lms_get_course_by_id(course_key)
     return None

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -89,9 +89,13 @@ def load_enough_xblock(location):  # pragma: nocover
     """
     # pylint: disable=import-error,import-outside-toplevel
     from xmodule.modulestore.django import modulestore
+    from openedx.core.djangoapps.xblock import api as xblock_api
 
     # Retrieve block from modulestore
-    return modulestore().get_item(location)
+    if isinstance(location.context_key, CourseKey):
+        return modulestore().get_item(location)
+    else:
+        return xblock_api.load_block(location, None)
 
 
 def load_block_as_user(location):  # pragma: nocover
@@ -233,7 +237,10 @@ def get_course_by_id(course_key):  # pragma: nocover
         from openedx.core.lib.courses import get_course_by_id as lms_get_course_by_id
     except ImportError:
         from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
-    return lms_get_course_by_id(course_key)
+
+    if isinstance(course_key, CourseKey):
+        return lms_get_course_by_id(course_key)
+    return None
 
 
 def user_course_access(*args, **kwargs):  # pragma: nocover

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -180,6 +180,13 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         self.compat.get_user_role.return_value = "student"
         self.compat.get_external_id_for_user.return_value = "12345"
 
+        block_compat_patcher = patch("lti_consumer.lti_xblock.compat")
+        self.addCleanup(block_compat_patcher.stop)
+        block_compat = block_compat_patcher.start()
+        block_compat.get_course_by_id.return_value = course
+        block_compat.get_user_role.return_value = "student"
+        block_compat.get_external_id_for_user.return_value = "12345"
+
         model_compat_patcher = patch("lti_consumer.models.compat")
         self.addCleanup(model_compat_patcher.stop)
         model_compat = model_compat_patcher.start()

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -317,6 +317,35 @@ class TestProperties(TestLtiConsumerXBlock):
         with self.assertRaises(LtiError):
             _ = self.xblock.role
 
+    def test_user_is_staff(self):
+        """
+        Test `user_is_staff` returns the correct status from the user service
+        """
+        fake_user = Mock()
+        fake_user.opt_attrs = {
+            'edx-platform.user_is_staff': True,
+            'edx-platform.is_authenticated': True,
+        }
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.assertTrue(self.xblock.user_is_staff)
+
+        fake_user.opt_attrs = {
+            'edx-platform.user_is_staff': False,
+            'edx-platform.is_authenticated': True,
+        }
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.assertFalse(self.xblock.user_is_staff)
+
+        fake_user.opt_attrs = {
+            'edx-platform.is_authenticated': True,
+        }
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.assertFalse(self.xblock.user_is_staff)
+
+        fake_user.opt_attrs = {}
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.assertFalse(self.xblock.user_is_staff)
+
     def test_course(self):
         """
         Test `course` calls compat.get_course_by_id
@@ -1931,6 +1960,87 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.xblock.runtime.service.return_value = None
         response = self.xblock.author_view({})
 
+        self.assertIn("mock-client_id", response.content)
+        self.assertIn("mock-keyset_url", response.content)
+        self.assertIn("mock-token_url", response.content)
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
+    @patch('lti_consumer.api.get_lti_1p3_content_url')
+    def test_student_view(self, mock_get_lti_1p3_content_url, mock_get_lti_1p3_launch_data):
+        """
+        Test that the student view is displayed as expected
+        """
+        # Mock lti data, i18n, and user services before rendering
+        mock_get_lti_1p3_content_url.return_value = 'lti_1p3_content_url'
+        mock_get_lti_1p3_launch_data.return_value = None
+        fake_user = Mock()
+        fake_user.opt_attrs = {
+            'edx-platform.is_authenticated': True,
+        }
+        fake_user.emails = ['student@example.com']
+        fake_service = Mock()
+        fake_service.get_current_user = Mock(return_value=fake_user)
+
+        def mock_service(_runtime, service_name):
+            """
+            Mock the user and i18n services
+            """
+            if service_name == 'user':
+                return fake_service
+            return None
+
+        self.xblock.runtime.service = Mock(side_effect=mock_service)
+
+        response = self.xblock.student_view({})
+        self.assertEqual(response.js_init_fn, 'LtiConsumerXBlock')
+        self.assertNotIn("LTI 1.3 Launches can only be performed from the LMS", response.content)
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
+    @patch('lti_consumer.api.get_lti_1p3_launch_info')
+    @patch('lti_consumer.api.get_lti_1p3_content_url')
+    def test_student_view_for_staff(
+        self,
+        mock_get_lti_1p3_content_url,
+        mock_get_launch_info,
+        mock_get_lti_1p3_launch_data,
+    ):
+        """
+        Test that the author view content is displayed with the student view when viewed by a staff user.
+        """
+        # Mock lti data, i18n, and user services before rendering
+        mock_get_lti_1p3_content_url.return_value = 'lti_1p3_content_url'
+        mock_get_lti_1p3_launch_data.return_value = None
+        mock_get_launch_info.return_value = {
+            'config_id': "mock-config_id",
+            'client_id': "mock-client_id",
+            'keyset_url': "mock-keyset_url",
+            'deployment_id': '1',
+            'oidc_callback': "mock-oidc_callback",
+            'token_url': "mock-token_url",
+        }
+        fake_user = Mock()
+        fake_user.opt_attrs = {
+            'edx-platform.user_is_staff': True,
+            'edx-platform.is_authenticated': True,
+        }
+        fake_user.emails = ['staff@example.com']
+        fake_service = Mock()
+        fake_service.get_current_user = Mock(return_value=fake_user)
+
+        def mock_service(_runtime, service_name):
+            """
+            Mock the user and i18n services
+            """
+            if service_name == 'user':
+                return fake_service
+            return None
+
+        self.xblock.runtime.service = Mock(side_effect=mock_service)
+
+        # Student view with staff user shows author params
+        response = self.xblock.student_view({})
+        self.assertEqual(response.js_init_fn, 'LtiConsumerXBlock')
+        self.assertIn("LTI 1.3 Launches can only be performed from the LMS", response.content)
         self.assertIn("mock-client_id", response.content)
         self.assertIn("mock-keyset_url", response.content)
         self.assertIn("mock-token_url", response.content)

--- a/test_settings.py
+++ b/test_settings.py
@@ -31,3 +31,6 @@ PLATFORM_NAME = "Your platform name here"
 
 # Learning MFE URL for start assessment testing
 LEARNING_MICROFRONTEND_URL = 'http://test.learning:2000'
+
+# Mimic running in Studio
+SERVICE_VARIANT = 'cms'


### PR DESCRIPTION
#### What are the relevant tickets?
Part of: https://github.com/openedx/frontend-app-authoring/issues/1514
Private-ref: [FAL-4032](https://tasks.opencraft.com/browse/FAL-4032)

#### What's this PR do?

Fixes errors thrown when previewing/editing LTI Consumer blocks in a Libraries v2 context.

#### How should this be manually tested?

To verify the issues fixed here:
1. Ensure that `lti_consumer` is in the list of `LIBRARY_SUPPORTED_BLOCKS` configured for your Authoring MFE.
1. Create a course, section, subsection, unit
2. Edit the course's Advanced Settings to add `lti_consumer` to the Advanced Module List.
3. Add 2 new LTI Consumer blocks to your course unit -- one to test LTI 1.1, and one to test LTI 1.3.
4. Edit the course blocks to configure them accordingly:
   - LTI 1.3: see [README#lti-13](https://github.com/openedx/xblock-lti-consumer?tab=readme-ov-file#lti-13)
     **Note** Take care to avoid any leading/trailing spaces when pasting values into the LMS Global reference tool.
   - LTI 1.1: see [README#lti-11](https://github.com/openedx/xblock-lti-consumer?tab=readme-ov-file#lti-11), though it's easier to borrow config and credentials from the Demo course's built-in LTI 1.1 blocks, see [Codeboard.io LTI Demonstration](http://apps.local.openedx.io:2001/authoring/course/course-v1:OpenedX+DemoX+DemoCourse/container/block-v1:OpenedX+DemoX+DemoCourse+type@vertical+block@5fdcd666f9bb4554938ee8a1ffb93d92?show=block-v1%3AOpenedX%2BDemoX%2BDemoCourse%2Btype%40lti%2Bblock%4094231b63c6c34ead863d2876a4762751) or [Code Grading Assessment via OpenJupyter](http://apps.local.openedx.io:2001/authoring/course/course-v1:OpenedX+DemoX+DemoCourse/container/block-v1:OpenedX+DemoX+DemoCourse+type@vertical+block@996f72a9a8b9429d8f887bd91c2e64cc/block-v1:OpenedX+DemoX+DemoCourse+type@sequential+block@971737e543204551bb34c4ca44e12b86?show=block-v1%3AOpenedX%2BDemoX%2BDemoCourse%2Btype%40lti%2Bblock%408e71d278e94f4913bc564cc6141fde53).
7. Copy/paste each LTI consumer xblock into a new content library.
9. Click on the LTI card to display its Preview in the sidebar, and/or click Expand to view it in a modal.
10. Click "Edit Component" to edit the LTI block.

To test this fix:
1. Install this branch in your CMS, e.g. `tutor dev exec cms pip install git+https://github.com/openedx/xblock-lti-consumer.git@refs/pull/536/head`
2. Repeat the testing steps above while watching the CMS logs.
3. Ensure the LTI Consumer Preview shows the "author view" content shown in the Studio course block, followed by the "student view" content shown in the LMS course block.
   See Notes below.
4. Ensure that you can edit and save changes to the library LTI Consumer block from within the library context.

#### Screenshots

Library Component Preview for a configured LTI 1.3 block:

![image](https://github.com/user-attachments/assets/6acd2d66-160e-49aa-8b41-300abab6fe8c)

#### Other information

1. The content library component preview uses `student_view`, but this XBlock has an `author_view`, which the Course view shows to Course Authors when viewing the block in Studio/Authoring MFE. Authors need to see these configuration details in order to configure LTI 1.3. So I've chosen to display the `author_view` content above the normal `student_view` content when shown to staff/instructors.
2. Because LTI 1.1 configurations rely on the course Advanced Settings > LTI Passport values, this configuration will not work from inside a Libraries v2 block. This issue will need to be addressed separately in the content libraries code.
3. Because the block's LTI 1.3 launch configuration is dependent on the block's `usage_id`, when you copy/paste an LTI 1.3 block from a course into a library, you'll need to completely reconfigure it in the IMS Reference Tool and on the LTI Consumer library block itself in order to see a working preview.