### PR TITLE
chore: remove deprecated variables from LtiConsumerXBlock

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -390,19 +390,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.settings
     )
 
-    # DEPRECATED - These variables were moved to the LtiConfiguration Model
-    lti_1p3_client_id = String(
-        display_name=_("LTI 1.3 Block Client ID - DEPRECATED"),
-        default='',
-        scope=Scope.settings,
-        help=_("DEPRECATED - This is now stored in the LtiConfiguration model."),
-    )
-    lti_1p3_block_key = String(
-        display_name=_("LTI 1.3 Block Key - DEPRECATED"),
-        default='',
-        scope=Scope.settings
-    )
-
     # Switch to enable/disable the LTI Advantage Deep linking service
     lti_advantage_deep_linking_enabled = Boolean(
         display_name=_("Deep linking"),


### PR DESCRIPTION
## Description

This PR removes `lti_1p3_client_id` and `lti_1p3_block_key`, variables that were deprecated since #113.

Those variables are no longer used from the xblock but from the LtiConfiguration model; also, the migration 005, created 5 years ago in #113, makes sure to copy the info from the xblock to the model.

## How to test

Apply the changes and verify if everything works as expected (you can try creating an LTI element in a Unit).
