### PR TITLE
feat: add django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [django42, quality]
+        toxenv: [django42, django52, quality]
 
     steps:
     - uses: actions/checkout@v2
@@ -38,8 +38,8 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.11' && matrix.toxenv=='py311-django42'
-      uses: codecov/codecov-action@v1
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
+      uses: codecov/codecov-action@v5
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.14.0 - 2025-04-14
+--------------------
+* Added support for Django 5.2
+
 9.13.4 - 2025-03-21
 -------------------
 * fix: update tests after pyjwt version upgrade

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 	pip-compile --upgrade -o requirements/tox.txt requirements/tox.in
 	pip-compile --upgrade -o requirements/ci.txt requirements/ci.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
+	# Let tox control the Django version for tests
+	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
+	mv requirements/test.tmp requirements/test.txt
 
 
 ## Localization targets

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.13.4'
+__version__ = '9.14.0'

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -1,7 +1,7 @@
 """
 Serializers for LTI-related endpoints
 """
-from django.utils import timezone
+from datetime import timezone
 from rest_framework import serializers, ISO_8601
 from rest_framework.reverse import reverse
 from opaque_keys import InvalidKeyError

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -2,14 +2,13 @@
 Unit tests for LTI models.
 """
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, call
 
 import ddt
 from Cryptodome.PublicKey import RSA
 from django.core.exceptions import ValidationError
 from django.test.testcases import TestCase
-from django.utils import timezone
 from edx_django_utils.cache import RequestCache
 from ccx_keys.locator import CCXBlockUsageLocator
 from opaque_keys.edx.locator import CourseLocator

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,13 +8,13 @@ appdirs==1.4.4
     # via fs
 asgiref==3.8.1
     # via django
-attrs==25.1.0
+attrs==25.3.0
     # via -r requirements/base.in
 bleach==6.2.0
     # via -r requirements/base.in
-boto3==1.36.17
+boto3==1.37.33
     # via fs-s3fs
-botocore==1.36.17
+botocore==1.37.33
     # via
     #   boto3
     #   s3transfer
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via edx-django-utils
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -41,27 +41,27 @@ django==4.2.19
     #   jsonfield
     #   openedx-django-pyfs
     #   openedx-filters
-django-appconf==1.0.6
+django-appconf==1.1.0
     # via django-statici18n
-django-config-models==2.7.0
+django-config-models==2.9.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
-django-filter==24.3
+django-filter==25.1
     # via -r requirements/base.in
 django-statici18n==2.6.0
     # via -r requirements/base.in
 django-waffle==4.2.0
     # via edx-django-utils
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via django-config-models
 dnspython==2.7.0
     # via pymongo
 edx-ccx-keys==2.0.2
     # via -r requirements/base.in
-edx-django-utils==7.1.0
+edx-django-utils==7.4.0
     # via django-config-models
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
@@ -85,11 +85,11 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 lazy==1.6
     # via -r requirements/base.in
-lxml==5.3.1
+lxml==5.3.2
     # via
     #   -r requirements/base.in
     #   xblock
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/base.in
     #   xblock
@@ -97,21 +97,21 @@ markupsafe==3.0.2
     # via
     #   mako
     #   xblock
-newrelic==10.6.0
+newrelic==10.9.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via -r requirements/base.in
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.in
-openedx-filters==1.13.0
+openedx-filters==2.0.1
     # via -r requirements/base.in
 pbr==6.1.1
     # via stevedore
-psutil==6.1.1
+psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.22.0
     # via
     #   -r requirements/base.in
     #   pyjwkest
@@ -119,7 +119,7 @@ pyjwkest==1.4.2
     # via -r requirements/base.in
 pyjwt==2.10.1
     # via -r requirements/base.in
-pymongo==4.11.1
+pymongo==4.12.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -127,15 +127,15 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   xblock
-pytz==2025.1
+pytz==2025.2
     # via xblock
 pyyaml==6.0.2
     # via xblock
 requests==2.32.3
     # via pyjwkest
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via boto3
-simplejson==3.19.3
+simplejson==3.20.1
     # via xblock
 six==1.17.0
     # via
@@ -146,11 +146,11 @@ six==1.17.0
     #   python-dateutil
 sqlparse==0.5.3
     # via django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via edx-opaque-keys
 urllib3==1.26.20
     # via
@@ -158,13 +158,13 @@ urllib3==1.26.20
     #   -c requirements/constraints.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.0.0
     # via xblock
 webencodings==0.5.1
     # via bleach
 webob==1.8.9
     # via xblock
-xblock==5.1.2
+xblock==5.2.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -16,12 +16,12 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via -r requirements/test.txt
 backports-tarfile==1.2.0
     # via
@@ -33,16 +33,16 @@ binaryornot==0.4.4
     #   cookiecutter
 bleach==6.2.0
     # via -r requirements/test.txt
-boto3==1.36.17
+boto3==1.37.33
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.36.17
+botocore==1.37.33
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==5.5.1
+cachetools==5.5.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -77,7 +77,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -89,16 +89,14 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.6.12
+coverage[toml]==7.8.0
     # via
     #   -r requirements/test.txt
     #   coveralls
 coveralls==4.0.1
     # via -r requirements/test.txt
-cryptography==44.0.0
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
+cryptography==44.0.2
+    # via -r requirements/test.txt
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.3.9
@@ -109,7 +107,7 @@ distlib==0.3.9
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -125,17 +123,17 @@ django==4.2.19
     #   openedx-django-pyfs
     #   openedx-filters
     #   xblock-sdk
-django-appconf==1.0.6
+django-appconf==1.1.0
     # via
     #   -r requirements/test.txt
     #   django-statici18n
-django-config-models==2.7.0
+django-config-models==2.9.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-filter==24.3
+django-filter==25.1
     # via -r requirements/test.txt
 django-statici18n==2.6.0
     # via -r requirements/test.txt
@@ -143,7 +141,7 @@ django-waffle==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -161,18 +159,18 @@ docutils==0.21.2
     #   readme-renderer
 edx-ccx-keys==2.0.2
     # via -r requirements/test.txt
-edx-django-utils==7.1.0
+edx-django-utils==7.4.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
 edx-lint==5.6.0
     # via -r requirements/test.txt
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-filters
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -204,7 +202,7 @@ importlib-metadata==8.6.1
     # via
     #   -r requirements/test.txt
     #   keyring
-isort==6.0.0
+isort==6.0.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -220,12 +218,7 @@ jaraco-functools==4.1.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -243,12 +236,12 @@ keyring==25.6.0
     #   twine
 lazy==1.6
     # via -r requirements/test.txt
-lxml==5.3.1
+lxml==5.3.2
     # via
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -270,18 +263,18 @@ mdurl==0.1.2
     # via
     #   -r requirements/test.txt
     #   markdown-it-py
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/test.txt
 more-itertools==10.6.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.6.0
+newrelic==10.9.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.20
+nh3==0.2.21
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -289,7 +282,7 @@ oauthlib==3.2.2
     # via -r requirements/test.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/test.txt
-openedx-filters==1.13.0
+openedx-filters==2.0.1
     # via -r requirements/test.txt
 packaging==24.2
     # via
@@ -302,7 +295,7 @@ pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
@@ -313,17 +306,17 @@ pluggy==1.5.0
     # via
     #   -r requirements/tox.txt
     #   tox
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/test.txt
 pycparser==2.22
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.22.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -336,7 +329,7 @@ pyjwkest==1.4.2
     # via -r requirements/test.txt
 pyjwt==2.10.1
     # via -r requirements/test.txt
-pylint==3.3.4
+pylint==3.3.6
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -356,7 +349,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.11.1
+pymongo==4.12.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -383,7 +376,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -415,20 +408,16 @@ rfc3986==2.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
     #   twine
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -446,7 +435,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -460,7 +449,7 @@ tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.24.1
+tox==4.25.0
     # via -r requirements/tox.txt
 twine==6.1.0
     # via -r requirements/test.txt
@@ -468,7 +457,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -r requirements/test.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -480,11 +469,11 @@ urllib3==1.26.20
     #   botocore
     #   requests
     #   twine
-virtualenv==20.29.2
+virtualenv==20.30.0
     # via
     #   -r requirements/tox.txt
     #   tox
-web-fragments==2.2.0
+web-fragments==3.0.0
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -498,11 +487,11 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.2
+xblock==5.2.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/test.txt
 zipp==3.21.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,15 +12,15 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.1.0
+attrs==25.3.0
     # via -r requirements/base.txt
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.36.17
+boto3==1.37.33
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.36.17
+botocore==1.37.33
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -41,7 +41,7 @@ click==8.1.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django==4.2.19
+django==4.2.20
     # via
     #   -r requirements/base.txt
     #   django-appconf
@@ -56,17 +56,17 @@ django==4.2.19
     #   jsonfield
     #   openedx-django-pyfs
     #   openedx-filters
-django-appconf==1.0.6
+django-appconf==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-statici18n
-django-config-models==2.7.0
+django-config-models==2.9.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-filter==24.3
+django-filter==25.1
     # via -r requirements/base.txt
 django-statici18n==2.6.0
     # via -r requirements/base.txt
@@ -74,7 +74,7 @@ django-waffle==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -84,13 +84,13 @@ dnspython==2.7.0
     #   pymongo
 edx-ccx-keys==2.0.2
     # via -r requirements/base.txt
-edx-django-utils==7.1.0
+edx-django-utils==7.4.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.7.0
     # via -r requirements/dev.in
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
@@ -122,15 +122,15 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 lazy==1.6
     # via -r requirements/base.txt
-lxml[html-clean]==5.3.1
+lxml[html-clean]==5.3.2
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
-lxml-html-clean==0.4.1
+lxml-html-clean==0.4.2
     # via lxml
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -139,7 +139,7 @@ markupsafe==3.0.2
     #   -r requirements/base.txt
     #   mako
     #   xblock
-newrelic==10.6.0
+newrelic==10.9.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -147,7 +147,7 @@ oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.13.0
+openedx-filters==2.0.1
     # via -r requirements/base.txt
 path==16.16.0
     # via edx-i18n-tools
@@ -157,7 +157,7 @@ pbr==6.1.1
     #   stevedore
 polib==1.2.0
     # via edx-i18n-tools
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -165,7 +165,7 @@ pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.22.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -173,7 +173,7 @@ pyjwkest==1.4.2
     # via -r requirements/base.txt
 pyjwt==2.10.1
     # via -r requirements/base.txt
-pymongo==4.11.1
+pymongo==4.12.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -186,7 +186,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   botocore
     #   xblock
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -199,11 +199,11 @@ requests==2.32.3
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/base.txt
     #   boto3
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -219,12 +219,12 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -233,7 +233,7 @@ urllib3==1.26.20
     #   -r requirements/base.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.0.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -245,7 +245,7 @@ webob==1.8.9
     # via
     #   -r requirements/base.txt
     #   xblock
-xblock==5.1.2
+xblock==5.2.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/xblock-lti-consumer/xblock-lti-consumer/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.8.0
+setuptools==78.1.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,21 +14,21 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via -r requirements/base.txt
 binaryornot==0.4.4
     # via cookiecutter
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.36.17
+boto3==1.37.33
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.36.17
+botocore==1.37.33
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -58,17 +58,17 @@ click==8.1.8
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-lint
 cookiecutter==2.6.0
     # via xblock-sdk
-cryptography==44.0.0
+cryptography==44.0.2
     # via -r requirements/quality.in
 ddt==1.7.2
     # via -r requirements/quality.in
 dill==0.3.9
     # via pylint
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -84,17 +84,17 @@ django==4.2.19
     #   openedx-django-pyfs
     #   openedx-filters
     #   xblock-sdk
-django-appconf==1.0.6
+django-appconf==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-statici18n
-django-config-models==2.7.0
+django-config-models==2.9.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-filter==24.3
+django-filter==25.1
     # via -r requirements/base.txt
 django-statici18n==2.6.0
     # via -r requirements/base.txt
@@ -102,7 +102,7 @@ django-waffle==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -112,13 +112,13 @@ dnspython==2.7.0
     #   pymongo
 edx-ccx-keys==2.0.2
     # via -r requirements/base.txt
-edx-django-utils==7.1.0
+edx-django-utils==7.4.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
 edx-lint==5.6.0
     # via -r requirements/quality.in
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
@@ -142,9 +142,9 @@ idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
-isort==6.0.0
+isort==6.0.1
     # via pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   code-annotations
     #   cookiecutter
@@ -157,12 +157,12 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 lazy==1.6
     # via -r requirements/base.txt
-lxml==5.3.1
+lxml==5.3.2
     # via
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -178,7 +178,7 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-newrelic==10.6.0
+newrelic==10.9.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -186,25 +186,25 @@ oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.13.0
+openedx-filters==2.0.1
     # via -r requirements/base.txt
 pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via pylint
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.22.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -214,7 +214,7 @@ pyjwkest==1.4.2
     # via -r requirements/base.txt
 pyjwt==2.10.1
     # via -r requirements/base.txt
-pylint==3.3.4
+pylint==3.3.6
     # via
     #   -r requirements/quality.in
     #   edx-lint
@@ -229,7 +229,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.11.1
+pymongo==4.12.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -249,7 +249,7 @@ python-slugify==8.0.4
     # via
     #   code-annotations
     #   cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -265,13 +265,13 @@ requests==2.32.3
     #   cookiecutter
     #   pyjwkest
     #   xblock-sdk
-rich==13.9.4
+rich==14.0.0
     # via cookiecutter
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/base.txt
     #   boto3
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -289,7 +289,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -301,7 +301,7 @@ tomlkit==0.13.2
     # via pylint
 types-python-dateutil==2.9.0.20241206
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -312,7 +312,7 @@ urllib3==1.26.20
     #   -r requirements/base.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.0.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -326,11 +326,11 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.2
+xblock==5.2.0
     # via
     #   -r requirements/base.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/quality.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,11 +14,11 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via -r requirements/base.txt
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -26,11 +26,11 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.36.17
+boto3==1.37.33
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.36.17
+botocore==1.37.33
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -60,23 +60,20 @@ click==8.1.8
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-lint
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.6.12
+coverage[toml]==7.8.0
     # via coveralls
 coveralls==4.0.1
     # via -r requirements/test.in
-cryptography==44.0.0
-    # via
-    #   -r requirements/test.in
-    #   secretstorage
+cryptography==44.0.2
+    # via -r requirements/test.in
 ddt==1.7.2
     # via -r requirements/test.in
 dill==0.3.9
     # via pylint
-django==4.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -92,17 +89,17 @@ django==4.2.19
     #   openedx-django-pyfs
     #   openedx-filters
     #   xblock-sdk
-django-appconf==1.0.6
+django-appconf==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-statici18n
-django-config-models==2.7.0
+django-config-models==2.9.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-filter==24.3
+django-filter==25.1
     # via -r requirements/base.txt
 django-statici18n==2.6.0
     # via -r requirements/base.txt
@@ -110,7 +107,7 @@ django-waffle==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -125,13 +122,13 @@ docutils==0.21.2
     # via readme-renderer
 edx-ccx-keys==2.0.2
     # via -r requirements/base.txt
-edx-django-utils==7.1.0
+edx-django-utils==7.4.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
 edx-lint==5.6.0
     # via -r requirements/test.in
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
@@ -159,7 +156,7 @@ idna==3.10
     #   requests
 importlib-metadata==8.6.1
     # via keyring
-isort==6.0.0
+isort==6.0.1
     # via pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -167,11 +164,7 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   code-annotations
     #   cookiecutter
@@ -186,12 +179,12 @@ keyring==25.6.0
     # via twine
 lazy==1.6
     # via -r requirements/base.txt
-lxml==5.3.1
+lxml==5.3.2
     # via
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -207,23 +200,23 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/test.in
 more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.6.0
+newrelic==10.9.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-nh3==0.2.20
+nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via -r requirements/base.txt
 openedx-django-pyfs==3.7.0
     # via -r requirements/base.txt
-openedx-filters==1.13.0
+openedx-filters==2.0.1
     # via -r requirements/base.txt
 packaging==24.2
     # via twine
@@ -231,19 +224,19 @@ pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via pylint
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/test.in
 pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.22.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -255,7 +248,7 @@ pyjwkest==1.4.2
     # via -r requirements/base.txt
 pyjwt==2.10.1
     # via -r requirements/base.txt
-pylint==3.3.4
+pylint==3.3.6
     # via
     #   edx-lint
     #   pylint-celery
@@ -269,7 +262,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.11.1
+pymongo==4.12.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -289,7 +282,7 @@ python-slugify==8.0.4
     # via
     #   code-annotations
     #   cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -317,17 +310,15 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.9.4
+rich==14.0.0
     # via
     #   cookiecutter
     #   twine
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/base.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
-simplejson==3.19.3
+simplejson==3.20.1
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -345,7 +336,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -359,7 +350,7 @@ twine==6.1.0
     # via -r requirements/test.in
 types-python-dateutil==2.9.0.20241206
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -371,7 +362,7 @@ urllib3==1.26.20
     #   botocore
     #   requests
     #   twine
-web-fragments==2.2.0
+web-fragments==3.0.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -385,11 +376,11 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock==5.1.2
+xblock==5.2.0
     # via
     #   -r requirements/base.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/test.in
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.1
+cachetools==5.5.2
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
@@ -20,7 +20,7 @@ packaging==24.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   tox
     #   virtualenv
@@ -28,7 +28,7 @@ pluggy==1.5.0
     # via tox
 pyproject-api==1.9.0
     # via tox
-tox==4.24.1
+tox==4.25.0
     # via -r requirements/tox.in
-virtualenv==20.29.2
+virtualenv==20.30.0
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{311, 312}-django{42}, quality
+envlist = py{311, 312}-django{42, 52}, quality
 
 [testenv]
 allowlist_externals =
     make
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<6.0
     -r{toxinidir}/requirements/test.txt
 commands =
     make test


### PR DESCRIPTION
In this PR:
- add django 5.2 support
- fix make upgrade command to compile test.txt correctly and Let tox control the Django version for tests, also upgrade requirments again after the fix.
  - This will fix this: https://github.com/openedx/xblock-lti-consumer/actions/runs/14445151146/job/40503912866?pr=551
- fix timezone import, as utc attribute was removed in Django 5.0.
  - This will fix this: https://github.com/openedx/xblock-lti-consumer/actions/runs/14446482262/job/40508199546?pr=551
- close #549 