### PR TITLE
fix: remove confirm dialog result append statements

### DIFF
--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -150,14 +150,12 @@ function LtiConsumerXBlock(runtime, element) {
                 // Show the button that triggered the event, i.e. the launch button.
                 triggerElement.show();
                 $dialog_container.remove()
-                $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>');
                 def.resolve("OK");
             })
             $dialog_container.find('#cancel-button').click(function () {
                 // Hide the button that triggered the event, i.e. the launch button.
                 triggerElement.show()
                 $dialog_container.remove()
-                $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>');
                 def.resolve("Cancel");
             })
             return def.promise();


### PR DESCRIPTION
This PR removes two calls that append text to the `body` element after an LTI launch is attempted.

These appear to be debug/testing statements and are not part of the LTI launch flow. Removing these avoids injecting the extra markup and has no effect on the core functionality.

Screenshot of the removed output:

<img width="1024" height="461" alt="image" src="https://github.com/user-attachments/assets/d9f93eb3-ef0d-428f-bd67-dbd0691334b3" />

