### PR TITLE
fix: initialize LTI passport from Studio instead of post_save

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,17 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ----------
 
+11.4.1 - 2026-09-02
+--------------------
+* Stop writing the LTI 1.3 passport id back to the XBlock from the
+  ``LtiConfiguration`` ``post_save`` signal. The signal also fires during LMS
+  requests, where blocks are bound to read-only field data for ``Scope.settings``,
+  so first-time passport creation raised ``InvalidScopeError`` and rolled back the
+  configuration row. The configuration is now the only writer during a launch.
+* Sync the block's ``lti_1p3_passport_id`` field from the database in a new
+  ``submit_studio_edits`` override on ``LtiConsumerXBlock``, so the field is only
+  written from Studio.
+
 11.4.0 - 2026-07-16
 --------------------
 * Add pagination support to the NRPS ``/context_membership`` endpoint, accepting

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.4.0'
+__version__ = '11.4.1'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -76,16 +76,15 @@ def _ensure_lti_passport(block, lti_config):
     )
 
     if key_mismatch:
-        from lti_consumer.plugin.compat import save_xblock  # pylint: disable=import-outside-toplevel
         passport = Lti1p3Passport.objects.create(
             lti_1p3_tool_public_key=block_public_key,
             lti_1p3_tool_keyset_url=block_keyset_url,
             name=f"Passport of {block.display_name}",
             context_key=block.context_id,
         )
-        # Persist new passport link on block so future loads use split passport.
-        block.lti_1p3_passport_id = str(passport.passport_id)
-        save_xblock(block)
+        # The caller links the split passport to the configuration, which is what future
+        # loads use. The block's `lti_1p3_passport_id` field is synced from Studio by
+        # `sync_lti_passport_id_to_block`, since writing it here would run in the LMS too.
         log.info("Created new LTI passport for %s", block.scope_ids.usage_id)
 
     return passport
@@ -120,6 +119,22 @@ def _get_or_create_local_lti_config(lti_version, block, config_store=LtiConfigur
         lti_config.save()
 
     return lti_config
+
+
+def sync_lti_passport_id_to_block(block):
+    """
+    Copy the configuration's passport_id onto the block's `lti_1p3_passport_id` field.
+
+    Only safe to call from Studio: the LMS binds blocks to read-only field data for
+    Scope.settings, so writing the field there raises `InvalidScopeError`.
+
+    Returns True if the field was changed, False otherwise.
+    """
+    passport = _get_lti_config_for_block(block).lti_1p3_passport
+    if passport and block.lti_1p3_passport_id != str(passport.passport_id):
+        block.lti_1p3_passport_id = str(passport.passport_id)
+        return True
+    return False
 
 
 def _get_config_by_config_id(config_id):

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1325,6 +1325,20 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         return fragment
 
+    @XBlock.handler
+    def submit_studio_edits(self, request, suffix=''):
+        """
+        Studio Save.
+
+        Reconciles the block's `lti_1p3_passport_id` field with the configuration
+        stored in the database, creating the configuration and its passport if they
+        don't exist yet. Doing it here means passport initialization never has to
+        write to the block from an LMS request, where Scope.settings is read-only.
+        """
+        from lti_consumer.api import sync_lti_passport_id_to_block  # pylint: disable=import-outside-toplevel
+        sync_lti_passport_id_to_block(self)
+        return super().submit_studio_edits(request, suffix)
+
     def author_view(self, context):
         """
         XBlock author view of this component.

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -404,6 +404,12 @@ class LtiConfiguration(models.Model):
     def get_or_create_lti_1p3_passport(self):
         """
         Create an LTI 1.3 Passport configuration for this course instance.
+
+        This never writes back to the XBlock: it runs from a post_save signal, which
+        also fires during LMS requests where blocks are bound to read-only field data
+        for Scope.settings. The configuration row is the authoritative link to the
+        passport; the block's `lti_1p3_passport_id` field is kept in sync from Studio
+        by `LtiConsumerXBlock.submit_studio_edits`.
         """
         passport = self.lti_1p3_passport
         block = None
@@ -429,9 +435,6 @@ class LtiConfiguration(models.Model):
                     passport.name = f"Passport of {block.display_name}"
                     passport.context_key = block.context_id
                     passport.save()
-                    block.lti_1p3_passport_id = str(passport.passport_id)
-                    block.save()
-                    compat.save_xblock(block)
             # We use update to avoid triggering post save signal as this function is itself
             # called from the post_save signal handler, this avoids double call to same function.
             LtiConfiguration.objects.filter(pk=self.pk).update(lti_1p3_passport=passport)

--- a/lti_consumer/tests/unit/test_api.py
+++ b/lti_consumer/tests/unit/test_api.py
@@ -19,6 +19,7 @@ from lti_consumer.api import (
     get_lti_1p3_launch_info,
     get_lti_1p3_launch_start_url,
     _get_or_create_local_lti_config,
+    sync_lti_passport_id_to_block,
     validate_lti_1p3_launch_data,
 )
 from lti_consumer.data import Lti1p3LaunchData, Lti1p3ProctoringLaunchData
@@ -341,17 +342,32 @@ class TestGetOrCreateLocalLtiConfiguration(Lti1P3TestCase):
         self.xblock.lti_1p3_tool_key_mode = 'public_key'
         self.xblock.lti_1p3_tool_public_key = 'new_key'
 
-        _get_or_create_local_lti_config(
-            lti_version=LtiConfiguration.LTI_1P3,
-            block=self.xblock
-        )
+        with patch('lti_consumer.plugin.compat.save_xblock') as save_xblock_mock:
+            lti_config = _get_or_create_local_lti_config(
+                lti_version=LtiConfiguration.LTI_1P3,
+                block=self.xblock
+            )
 
         # Original passport unchanged
         passport.refresh_from_db()
         self.assertEqual(passport.lti_1p3_tool_public_key, 'shared_key')
 
-        # Block has new passport
-        self.assertNotEqual(self.xblock.lti_1p3_passport_id, str(passport.passport_id))
+        # Configuration points at the new passport, and the block was not written to.
+        self.assertNotEqual(lti_config.lti_1p3_passport, passport)
+        self.assertEqual(lti_config.lti_1p3_passport.lti_1p3_tool_public_key, 'new_key')
+        save_xblock_mock.assert_not_called()
+
+    def test_sync_lti_passport_id_to_block(self):
+        """
+        Check that the block's passport_id field is synced from the configuration.
+        """
+        self.assertTrue(sync_lti_passport_id_to_block(self.xblock))
+
+        lti_config = LtiConfiguration.objects.get(location=self.location)
+        self.assertEqual(self.xblock.lti_1p3_passport_id, str(lti_config.lti_1p3_passport.passport_id))
+
+        # Nothing to do on a second call.
+        self.assertFalse(sync_lti_passport_id_to_block(self.xblock))
 
     def test_passport_unchanged_when_keys_match(self):
         """

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -781,6 +781,27 @@ class TestProperties(TestLtiConsumerXBlock):
             self.assertTrue(mock_timezone_now.called)
 
 
+class TestSubmitStudioEdits(TestLtiConsumerXBlock):
+    """
+    Unit tests for LtiConsumerXBlock.submit_studio_edits()
+    """
+
+    @patch("lti_consumer.lti_xblock.external_config_filter_enabled", return_value=False)
+    @patch("lti_consumer.lti_xblock.database_config_enabled", return_value=False)
+    def test_passport_id_synced_from_configuration(self, *_args):
+        """
+        Saving in Studio populates the block's passport_id from the configuration.
+        """
+        self.assertEqual(self.xblock.lti_1p3_passport_id, '')
+
+        request = make_request(json.dumps({'values': {}, 'defaults': []}), 'POST')
+        response = self.xblock.submit_studio_edits(request, '')
+
+        self.assertEqual(json.loads(response.body.decode('utf-8')), {'result': 'success'})
+        lti_config = LtiConfiguration.objects.get(location=self.xblock.scope_ids.usage_id)
+        self.assertEqual(self.xblock.lti_1p3_passport_id, str(lti_config.lti_1p3_passport.passport_id))
+
+
 @ddt.ddt
 class TestEditableFields(TestLtiConsumerXBlock):
     """

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -517,6 +517,32 @@ class TestLtiConfigurationModel(TestBaseWithPatch):
             external_config['lti_advantage_deep_linking_launch_url'],
         )
 
+    def test_get_or_create_lti_1p3_passport_does_not_write_to_block(self):
+        """
+        Test that creating a passport doesn't write back to the XBlock.
+
+        This runs from a post_save signal, which also fires during LMS requests, where
+        blocks are bound to read-only field data for Scope.settings.
+        """
+        xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
+        xblock.lti_1p3_passport_id = ''
+        self._load_block_patch.return_value = xblock
+
+        with patch.object(xblock, 'save') as block_save_mock, \
+                patch('lti_consumer.plugin.compat.save_xblock') as save_xblock_mock:
+            config = LtiConfiguration.objects.create(
+                location=xblock.scope_ids.usage_id,
+                version=LtiConfiguration.LTI_1P3,
+            )
+
+        # The passport is created and linked to the configuration, which is authoritative.
+        self.assertIsNotNone(config.lti_1p3_passport)
+        self.assertEqual(config.lti_1p3_passport.name, f"Passport of {xblock.display_name}")
+        # But the block is left untouched.
+        block_save_mock.assert_not_called()
+        save_xblock_mock.assert_not_called()
+        self.assertEqual(xblock.lti_1p3_passport_id, '')
+
     @patch.object(LtiConfiguration, 'sync_configurations')
     def test_save(self, sync_configurations_mock):
         """Test save method."""


### PR DESCRIPTION
Closes #699 & #647

## Problem

`get_or_create_lti_1p3_passport()` writes the new passport id back to the
XBlock (`block.save()` + `save_xblock()`), and it runs from a `post_save`
signal that also fires in the LMS, where `Scope.settings` is read-only:

```
InvalidScopeError: ....lti_1p3_passport_id is read-only, cannot set
```

`get_or_create()` wraps this in `transaction.atomic()`, so the exception rolls
back the `LtiConfiguration` insert as well — the row never persists and every
later launch fails the same way. We see it in production on `11.4.0`.

For blocks with `launch_target='modal'` the LMS is always first: the modal
button posts `plugin.modal` to the parent frame, which `frontend-app-learning`
handles and `frontend-app-authoring` does not, so no launch ever happens while
authoring.

`_ensure_lti_passport()` writes to the block the same way on its split path.

## Change

Passport creation now only touches the database, which already holds the
authoritative link, and the block's `lti_1p3_passport_id` is written from
Studio only:

- `models.py` / `api.py` — drop the block writes from
  `get_or_create_lti_1p3_passport()` and `_ensure_lti_passport()`.
- `api.py` — new `sync_lti_passport_id_to_block()` helper.
- `lti_xblock.py` — `submit_studio_edits` override calling that helper, the
  Studio hook proposed in the issue. Same delegating pattern as
  `LibrarySourcedBlock` in `edx-platform`: `@XBlock.handler` forwarding
  `(request, suffix)` to the mixin's `@XBlock.json_handler`.

The existing dirty check in `_get_or_create_local_lti_config()` still covers
imports and programmatic creates, and `add_xml_to_node()` still reads
`passport_id` from the DB at export time. No migration.

## Tests

- Passport creation links the configuration but doesn't touch the block.
- The split path no longer calls `save_xblock`.
- A Studio save populates `lti_1p3_passport_id` from the configuration.

765 tests passing, `pycodestyle` and `pylint` clean.
