### PR TITLE
fix: publish zero value AGS scores to the gradebook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,25 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ----------
 
+11.4.2 - 2026-09-10
+--------------------
+* Publish AGS scores with a ``scoreGiven`` of ``0`` to the LMS gradebook. The
+  grade publishing signal tested ``scoreGiven`` for truthiness, so a valid zero
+  score was treated as a missing one and never reached the gradebook.
+* Reject a ``scoreMaximum`` that is unset or not positive whenever ``scoreGiven``
+  is present. ``LtiAgsScore.clean()`` had the same truthiness bug, and a
+  ``scoreMaximum`` of ``0`` is not a usable denominator: it could be saved through
+  the ORM or admin, was then silently skipped by the publishing signal, yet was
+  still reported as a successful result by ``LtiAgsResultSerializer``.
+* Reject an AGS ``scoreMaximum`` of ``0`` at the API too, with a "must be a positive
+  number" error rather than the misleading "is a required field".
+* Report an LTI 1.1 ``module_score`` of ``0`` from the result service instead of
+  omitting it, which reported a learner scored zero as ungraded. Same falsy-zero
+  pattern, on the LTI 1.1 side.
+* Log the reason a grade publish was skipped -- grading progress, resource link id,
+  score given/maximum, and the block's ``has_score``/past-due state -- instead of
+  only ever logging a successful publish.
+
 11.4.1 - 2026-09-02
 --------------------
 * Stop writing the LTI 1.3 passport id back to the XBlock from the

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.4.1'
+__version__ = '11.4.2'

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -145,10 +145,14 @@ class LtiAgsScoreSerializer(serializers.ModelSerializer):
 
     def validate_scoreMaximum(self, value):
         """
-        Ensure that scoreMaximum is set when scoreGiven is provided and not None
+        Ensure that scoreMaximum is set to a usable, positive value when scoreGiven is provided.
         """
-        if not value and self.initial_data.get('scoreGiven', None) is not None:
+        if self.initial_data.get('scoreGiven', None) is None:
+            return value
+        if value is None:
             raise serializers.ValidationError('scoreMaximum is a required field when providing a scoreGiven value.')
+        if value <= 0:
+            raise serializers.ValidationError('scoreMaximum must be a positive number when scoreGiven is provided.')
         return value
 
     class Meta:

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1631,7 +1631,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         self.runtime.service(self, 'rebind_user').rebind_noauth_module_to_user(self, user)
         args = []
-        if self.module_score:
+        # `is not None`, not a truthiness check: a `module_score` of 0 is falsy but a legitimate,
+        # already-graded score -- the same falsy-zero pattern fixed for LTI 1.3 AGS elsewhere.
+        if self.module_score is not None:
             args.extend([self.module_score, self.score_comment])
         return lti_consumer.get_result(*args)
 

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -947,8 +947,15 @@ class LtiAgsScore(models.Model):
     def clean(self):
         super().clean()
 
-        # 'scoreMaximum' represents the denominator and MUST be present when 'scoreGiven' is present
-        if self.score_given and self.score_maximum is None:
+        # 'scoreMaximum' represents the denominator and MUST be a usable, positive value when
+        # 'scoreGiven' is present -- `score_maximum <= 0` can't be published either (see
+        # `publish_grade_on_score_update`), and letting it through here made it possible for
+        # `LtiAgsResultSerializer.get_resultMaximum` to report a fabricated "successful" result
+        # for a score that was never actually published to the gradebook.
+        # Note: this must be an `is not None` check on `score_given`, not a truthiness check,
+        # since a `scoreGiven` of 0 is falsy but a legitimate value that still requires a
+        # `scoreMaximum`.
+        if self.score_given is not None and not self.score_maximum:
             raise ValidationError({'score_maximum': 'cannot be unset when score_given is set'})
 
     def save(self, *args, **kwargs):

--- a/lti_consumer/signals/signals.py
+++ b/lti_consumer/signals/signals.py
@@ -44,17 +44,54 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
         )
         return
 
-    # Before starting to publish grades to the LMS, check that:
-    # 1. The grade being submitted in the final one - `FullyGraded`
-    # 2. This LineItem is linked to a LMS grade - the `LtiResouceLinkId` field is set
-    # 3. There's a valid grade in this score - `scoreGiven` is set
-    if instance.grading_progress == LtiAgsScore.FULLY_GRADED \
-            and line_item.resource_link_id \
-            and instance.score_given:
-        try:
-            # Load block using LMS APIs and check if the block is graded and still accept grades.
-            block = compat.load_block_as_user(line_item.resource_link_id)
-            if block.has_score and (not block.is_past_due() or block.accept_grades_past_due):
+    # The grade being submitted must be the final one - `FullyGraded`. This is routine, expected
+    # tool behavior to not be the case yet (interim `Pending`/`InProgress` saves are far more
+    # common than the final one), so it's silently skipped here, not logged, to avoid flooding
+    # the logs.
+    if instance.grading_progress != LtiAgsScore.FULLY_GRADED:
+        return
+
+    # From here on the score is final, so failing to publish it is the actionable case worth
+    # logging below. Before publishing to the LMS, check that:
+    # 1. This LineItem is linked to a LMS grade - the `LtiResouceLinkId` field is set
+    # 2. There's a grade present in this score - `scoreGiven` is present
+    # 3. `scoreMaximum` is a usable, positive denominator for the normalized score below
+    # Note: (2) and (3) must be `is not None`/range checks, not truthiness checks, since a
+    # `scoreGiven` or `scoreMaximum` of 0 is falsy but a legitimate value for the former.
+    can_publish = (
+        bool(line_item.resource_link_id) and
+        instance.score_given is not None and
+        instance.score_maximum is not None and
+        instance.score_maximum > 0
+    )
+    if not can_publish:
+        log.info(
+            "LTI AGS grade publish skipped: score=%r grading_progress=%s resource_link_id=%s "
+            "score_given=%s score_maximum=%s.",
+            instance,
+            instance.grading_progress,
+            line_item.resource_link_id,
+            instance.score_given,
+            instance.score_maximum,
+        )
+        return
+
+    try:
+        # Load block using LMS APIs and check if the block is graded and still accept grades.
+        block = compat.load_block_as_user(line_item.resource_link_id)
+        if not block.has_score:
+            log.info(
+                "LTI AGS grade publish skipped: score=%r resource_link_id=%s has_score=%s.",
+                instance,
+                line_item.resource_link_id,
+                block.has_score,
+            )
+        else:
+            # Computed once and reused below: previously `is_past_due()`/`accept_grades_past_due`
+            # were never evaluated at all when `has_score` was False (short-circuited by `and`),
+            # so neither is touched here unless `has_score` is True.
+            is_past_due = block.is_past_due()
+            if not is_past_due or block.accept_grades_past_due:
                 # Map external ID to platform user
                 user = compat.get_user_from_external_user_id(instance.user_id)
 
@@ -73,17 +110,27 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
                     score,
                 )
                 block.set_user_module_score(user, score, block.max_score(), instance.comment)
+            else:
+                log.info(
+                    "LTI AGS grade publish skipped: score=%r resource_link_id=%s has_score=%s "
+                    "is_past_due=%s accept_grades_past_due=%s.",
+                    instance,
+                    line_item.resource_link_id,
+                    block.has_score,
+                    is_past_due,
+                    block.accept_grades_past_due,
+                )
 
-        # This is a catch all exception to catch and log any issues related to loading the block
-        # from the modulestore and other LMS API calls
-        except Exception as exc:
-            log.exception(
-                "Error while publishing score %r to block %s to LMS: %s",
-                instance,
-                line_item.resource_link_id,
-                exc,
-            )
-            raise exc
+    # This is a catch all exception to catch and log any issues related to loading the block
+    # from the modulestore and other LMS API calls
+    except Exception as exc:
+        log.exception(
+            "Error while publishing score %r to block %s to LMS: %s",
+            instance,
+            line_item.resource_link_id,
+            exc,
+        )
+        raise exc
 
 
 @receiver(post_save, sender=LtiConfiguration, dispatch_uid='create_lti_1p3_passport')

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -499,6 +499,29 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         call_args = self.xblock.set_user_module_score.call_args.args
         self.assertEqual(call_args, ('user_mock', 0.83, 1, 'This is exceptional work.'))
 
+    def test_xblock_grade_publish_with_zero_score(self):
+        """
+        Test that a `scoreGiven` of 0 is published to the LMS end-to-end, rather than being
+        silently skipped by the falsy-zero check this fix corrects.
+        """
+        # Set up LMS mocks
+        self._compat_mock.load_block_as_user.return_value = self.xblock
+        self._compat_mock.get_user_from_external_user_id.return_value = 'user_mock'
+        self.xblock.set_user_module_score = Mock()
+
+        # Set xblock attribute and make score request
+        self.xblock.has_score = True
+        self._post_lti_score({
+            "scoreGiven": 0,
+            "gradingProgress": "FullyGraded",
+        })
+
+        # Check if publish grade was called
+        self.xblock.set_user_module_score.assert_called_once()
+
+        call_args = self.xblock.set_user_module_score.call_args.args
+        self.assertEqual(call_args, ('user_mock', 0, 1, 'This is exceptional work.'))
+
     def test_grade_publish_score_bigger_than_maximum(self):
         """
         Test when given score is bigger than maximum score.
@@ -822,6 +845,36 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(LtiAgsScore.objects.all().count(), 0)
         self.assertEqual(response.status_code, 400)
         assert 'scoreMaximum' in response.data.keys()
+
+    def test_create_score_with_zero_score_maximum(self):
+        """
+        Test invalid request with `scoreMaximum: 0` -- present, but not a usable denominator.
+
+        Distinct from `test_create_score_with_missing_score_maximum`: `scoreMaximum` here is not
+        absent, so `validate_scoreMaximum` must reject it via an explicit `value <= 0` check
+        rather than the `value is None` check alone, and report the more accurate "must be a
+        positive number" message rather than "is a required field".
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/score')
+
+        response = self.client.post(
+            self.scores_endpoint,
+            data=json.dumps({
+                "timestamp": self.late_timestamp,
+                "scoreGiven": 0,
+                "scoreMaximum": 0,
+                "comment": "This is exceptional work.",
+                "activityProgress": LtiAgsScore.INITIALIZED,
+                "gradingProgress": LtiAgsScore.NOT_READY,
+                "userId": self.primary_user_id
+            }),
+            content_type="application/vnd.ims.lis.v1.score+json",
+        )
+
+        self.assertEqual(LtiAgsScore.objects.all().count(), 0)
+        self.assertEqual(response.status_code, 400)
+        assert 'scoreMaximum' in response.data.keys()
+        assert 'positive number' in str(response.data['scoreMaximum'])
 
     def test_erase_score(self):
         """

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1535,6 +1535,25 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
         mock_lti_consumer.get_result.assert_called_with(0.5, 'test')
 
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.module_score', PropertyMock(return_value=0))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.score_comment', PropertyMock(return_value='test'))
+    def test_consumer_get_result_called_with_zero_score(self):
+        """
+        Test LtiConsumer.get_result is called with a `module_score` of 0, rather than that score
+        being silently omitted.
+
+        `module_score` is falsy for a real, graded score of 0.0; `_result_service_get` previously
+        checked it for truthiness, so a learner scored 0 was reported as ungraded (no
+        `resultScore` in the response) instead of graded 0 -- the same falsy-zero pattern fixed
+        for LTI 1.3 AGS elsewhere in this change.
+        """
+        mock_lti_consumer = Mock()
+        mock_user = Mock()
+
+        self.xblock._result_service_get(mock_lti_consumer, mock_user)  # pylint: disable=protected-access
+
+        mock_lti_consumer.get_result.assert_called_with(0, 'test')
+
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.clear_user_module_score', Mock(return_value=True))
     @patch('lti_consumer.lti_xblock.parse_result_json')
     def test_consumer_put_result_called(self, mock_parse_result_json):

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -725,6 +725,34 @@ class TestLtiAgsScoreModel(TestBaseWithPatch):
             self.score.score_maximum = None
             self.score.save()
 
+    def test_no_score_max_fails_when_setting_zero_score(self):
+        """
+        Test that the model raises the same exception for a `scoreGiven` of 0 without
+        `scoreMaximum`, not just for a truthy `scoreGiven`.
+
+        `clean()` previously checked `self.score_given` for truthiness, which let a
+        `scoreGiven` of 0 (falsy but valid) through without `scoreMaximum` set.
+        """
+        with self.assertRaises(ValidationError):
+            self.score.score_given = 0
+            self.score.score_maximum = None
+            self.score.save()
+
+    def test_score_max_fails_when_zero_with_score_given_set(self):
+        """
+        Test that the model rejects `scoreMaximum=0` alongside a set `scoreGiven`, not just
+        `scoreMaximum=None`.
+
+        A `scoreMaximum` of 0 isn't a usable denominator either, and previously `clean()` only
+        checked for `None`, so this combination could be saved via the ORM/admin -- silently
+        skipped by `publish_grade_on_score_update`, yet still reported as a fabricated
+        "successful" result (`resultMaximum: 1`) by `LtiAgsResultSerializer.get_resultMaximum`.
+        """
+        with self.assertRaises(ValidationError):
+            self.score.score_given = 10
+            self.score.score_maximum = 0
+            self.score.save()
+
     def test_repr(self):
         """
         Test String representation of model.

--- a/lti_consumer/tests/unit/test_signals.py
+++ b/lti_consumer/tests/unit/test_signals.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from ddt import data, ddt, unpack
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from opaque_keys.edx.keys import UsageKey
 from openedx_events.content_authoring.data import DuplicatedXBlockData, LibraryBlockData, XBlockData
@@ -117,6 +118,106 @@ class PublishGradeOnScoreUpdateTest(TestCase):
         self._block_mock.set_user_module_score.assert_called_once()
         self._signals_compat_mock.get_user_from_external_user_id.assert_called_once()
         self._signals_compat_mock.load_block_as_user.assert_called_once()
+
+    def test_grade_publish_with_zero_score(self):
+        """
+        Test that a `scoreGiven` of 0 is published like any other score.
+
+        `score_given` is falsy for a `FloatField` value of `0.0`. Before this fix, the guard used
+        a truthiness check (`and instance.score_given`) and silently skipped a legitimate zero
+        score; it must now use `is not None` so 0 is treated as a present, valid grade.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        LtiAgsScore.objects.create(
+            line_item=line_item,
+            score_given=0,
+            score_maximum=100,
+            activity_progress=LtiAgsScore.COMPLETED,
+            grading_progress=LtiAgsScore.FULLY_GRADED,
+            user_id="test",
+            timestamp=datetime.now(),
+        )
+
+        self._block_mock.set_user_module_score.assert_called_once()
+        call_args = self._block_mock.set_user_module_score.call_args.args
+        self.assertEqual(call_args[1], 0)
+
+    def test_grade_publish_not_done_when_score_given_missing(self):
+        """
+        Test that grade publish is still skipped (not errored) when `score_given` is absent, e.g.
+        an AGS "erase score" request that nulls out `scoreGiven`/`scoreMaximum`.
+
+        Unlike the zero-score case above, this is unchanged behavior: `score_given=None` was
+        already falsy under the old truthiness check, and is also caught by the new
+        `is not None` check, so this is a lock-in test rather than a new assertion.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        LtiAgsScore.objects.create(
+            line_item=line_item,
+            score_given=None,
+            score_maximum=None,
+            activity_progress=LtiAgsScore.COMPLETED,
+            grading_progress=LtiAgsScore.FULLY_GRADED,
+            user_id="test",
+            timestamp=datetime.now(),
+        )
+
+        self._block_mock.set_user_module_score.assert_not_called()
+        self._signals_compat_mock.load_block_as_user.assert_not_called()
+
+    def test_grade_publish_not_done_when_score_maximum_zero(self):
+        """
+        Test that `score_maximum=0` alongside a set `score_given` is rejected at save time,
+        never reaching the publish signal at all.
+
+        This combination can't be produced through the AGS API (the serializer rejects a
+        `scoreMaximum` of 0). It previously could still be produced via the Django admin or
+        direct ORM access -- `MinValueValidator(0)` and the old `LtiAgsScore.clean()` both
+        permitted it (0 is a valid, non-`None` value) -- reaching this signal, whose normalized-
+        score division would otherwise crash on it (worked around, at the time, by a
+        `score_maximum > 0` guard in the signal itself).
+
+        `LtiAgsScore.clean()` now rejects `score_maximum <= 0` whenever `score_given` is set
+        (not just `score_maximum is None`), closing the gap at the source: this state can no
+        longer be saved at all, so the signal's own guard is never exercised by it. See
+        `lti_consumer.tests.unit.test_models.TestLtiAgsScoreModel.
+        test_score_max_fails_when_zero_with_score_given_set` for the model-level assertion.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        with self.assertRaises(ValidationError):
+            LtiAgsScore.objects.create(
+                line_item=line_item,
+                score_given=10,
+                score_maximum=0,
+                activity_progress=LtiAgsScore.COMPLETED,
+                grading_progress=LtiAgsScore.FULLY_GRADED,
+                user_id="test",
+                timestamp=datetime.now(),
+            )
+
+        self._block_mock.set_user_module_score.assert_not_called()
+        self._signals_compat_mock.load_block_as_user.assert_not_called()
 
 
 @ddt


### PR DESCRIPTION
## Description

An LTI tool that posts a valid AGS score of `scoreGiven: 0.0` gets a `201 Created`, but the zero never reaches the Open edX gradebook. `publish_grade_on_score_update` gated grade publishing on `instance.score_given` being *truthy*, so `0.0` was indistinguishable from a missing score and the signal returned without publishing anything.

The same falsy-zero pattern turns out to appear in three more places, all fixed here:

- **`LtiAgsScore.clean()`** skipped its "`scoreMaximum` is required" check for a zero score, and only ever rejected a `scoreMaximum` of `None`. A `scoreMaximum` of `0` is not a usable denominator either: it could be saved through the ORM or the Django admin, was then silently skipped by the publishing signal (the normalized-score division would otherwise raise), yet was still reported as a successful result by `LtiAgsResultSerializer.get_resultMaximum`.
- **`LtiAgsScoreSerializer.validate_scoreMaximum`** rejected `scoreMaximum: 0` only incidentally, through a truthiness check, and reported it as "is a required field" when the field was in fact present.
- **`LtiConsumerXBlock._result_service_get`** omitted a `module_score` of `0` from the LTI 1.1 result response, so a learner scored zero was reported as ungraded. Same bug, LTI 1.1 side.

While in here, the publishing signal also gained logging for *why* a final score was not published — grading progress, resource link id, score given/maximum, and the block's `has_score`/past-due state. Previously only a successful publish was ever logged, which is what made this class of bug invisible in production logs. Interim `Pending`/`InProgress` saves are still skipped silently, since those are routine and would flood the logs.

## Fixes

Fixes #695

## Testing

New tests, all failing on `master` and passing here:

- `test_grade_publish_with_zero_score` — a `FullyGraded` score of `0` out of `100` is published to the block as `0`.
- `test_xblock_grade_publish_with_zero_score` — the same thing end-to-end through the AGS scores endpoint.
- `test_grade_publish_not_done_when_score_maximum_zero` — `scoreMaximum: 0` with a set `scoreGiven` is rejected at save time and never reaches the signal.
- `test_create_score_with_zero_score_maximum` — the API rejects it with the "must be a positive number" message.
- `test_no_score_max_fails_when_setting_zero_score`, `test_score_max_fails_when_zero_with_score_given_set` — model-level assertions for the two `clean()` gaps.
- `test_consumer_get_result_called_with_zero_score` — LTI 1.1 result service reports a score of `0`.

Plus `test_grade_publish_not_done_when_score_given_missing`, a lock-in test that an AGS "erase score" request (explicit `null` `scoreGiven`) is still skipped rather than published as zero.

Full suite (773 tests) passes; `pycodestyle` and `pylint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)