### PR TITLE
feat: add structured logging to the LTI 1.3 launch and AGS flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,28 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ----------
 
+11.5.0 - 2026-09-10
+--------------------
+* Add structured logging across the LTI 1.3 launch and LTI Advantage AGS flows, so
+  a failed tool integration can be diagnosed from the logs alone:
+
+  * The OIDC launch start, the login redirect, the preflight response received from
+    the tool, the assembled launch message (including deep linking), and the final
+    hand-off to the browser.
+  * Access token issuance, recording requested versus granted scopes, and every
+    token scope check -- at ``WARNING`` when the check denies the request, naming
+    the required scopes against those the token carries. This is the most common
+    cause of an otherwise unexplained AGS ``403``.
+  * Every AGS request and its outcome, logged from ``initial()`` (before
+    authentication, so invalid credentials are logged too) and ``finalize_response()``,
+    with the error keys and messages summarized for error responses.
+
+  No JWTs, access tokens or client assertions are logged. Learner PII is kept out of
+  the logs: the ``name``/``email``/``preferred_username`` launch claims are redacted,
+  and the AGS ``userId`` and ``comment`` fields are logged as a length only. Values
+  are truncated and newline-escaped so a tool-supplied payload cannot bloat or forge
+  log lines.
+
 11.4.1 - 2026-09-02
 --------------------
 * Stop writing the LTI 1.3 passport id back to the XBlock from the

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.4.1'
+__version__ = '11.5.0'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -274,6 +274,16 @@ def get_lti_1p3_launch_start_url(
     elif dl_content_id:
         launch_data.deep_linking_content_item_id = dl_content_id
 
+    log.info(
+        'LTI 1.3 OIDC launch starting: config_id=%s resource_link_id=%s message_type=%s '
+        'deep_link_launch=%s dl_content_id=%s.',
+        launch_data.config_id,
+        launch_data.resource_link_id,
+        launch_data.message_type,
+        deep_link_launch,
+        dl_content_id,
+    )
+
     # Prepare and return OIDC flow start url
     return lti_consumer.prepare_preflight_url(launch_data)
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -29,6 +29,36 @@ from .nprs import LtiNrps
 log = logging.getLogger(__name__)
 
 
+# Launch message claims that carry user PII. The launch message is logged in full to make
+# tool-integration problems diagnosable, so these are replaced with a placeholder first --
+# `sub` is kept, since it is an opaque, platform-generated identifier and is the only way to
+# correlate a launch with the tool's own logs.
+LTI_1P3_PII_CLAIMS = frozenset({
+    'name',
+    'given_name',
+    'family_name',
+    'middle_name',
+    'email',
+    'picture',
+    'preferred_username',
+    'address',
+    'phone_number',
+})
+
+
+def redact_pii_claims(claims):
+    """
+    Return a copy of an LTI 1.3 launch message with PII claim values replaced by a placeholder,
+    so the message can be logged without emitting a learner's name or email address.
+    """
+    if not isinstance(claims, dict):
+        return claims
+    return {
+        key: '<redacted>' if key in LTI_1P3_PII_CLAIMS else value
+        for key, value in claims.items()
+    }
+
+
 class LtiConsumer1p3:
     """
     LTI 1.3 Consumer Implementation
@@ -146,6 +176,18 @@ class LtiConsumer1p3:
             "login_hint": login_hint,
             "lti_message_hint": launch_data_key,
         }
+
+        log.info(
+            'LTI 1.3 OIDC login redirect prepared for oidc_url=%s: iss=%s client_id=%s deployment_id=%s '
+            'target_link_uri=%s login_hint=%s lti_message_hint=%s.',
+            self.oidc_url,
+            self.iss,
+            self.client_id,
+            self.deployment_id,
+            target_link_uri,
+            login_hint,
+            launch_data_key,
+        )
 
         return oidc_url + urlencode(parameters)
 
@@ -413,6 +455,12 @@ class LtiConsumer1p3:
             "nonce": preflight_response.get("nonce")
         })
 
+        log.info(
+            'LTI 1.3 launch request assembled for target_link_uri=%s: claims=%s.',
+            lti_launch_message.get('https://purl.imsglobal.org/spec/lti/claim/target_link_uri'),
+            redact_pii_claims(lti_launch_message),
+        )
+
         return {
             "state": preflight_response.get("state"),
             "id_token": self.key_handler.encode_and_sign(
@@ -500,6 +548,13 @@ class LtiConsumer1p3:
         # https://tools.ietf.org/html/rfc6749
         scopes_str = " ".join(valid_scopes)
 
+        log.info(
+            'LTI 1.3 access token issued: client_id=%s requested_scopes=%s granted_scopes=%s.',
+            self.client_id,
+            requested_scopes,
+            valid_scopes,
+        )
+
         # This response is compliant with RFC 6749
         # https://tools.ietf.org/html/rfc6749#section-4.4.3
         return {
@@ -553,7 +608,16 @@ class LtiConsumer1p3:
         # If `allowed_scopes` is empty, return true (just check
         # token validity).
         if allowed_scopes:
-            return any(scope in allowed_scopes for scope in token_scopes)
+            granted = any(scope in allowed_scopes for scope in token_scopes)
+            log_at = log.info if granted else log.warning
+            log_at(
+                'LTI 1.3 token scope check: client_id=%s token_scopes=%s required_scopes=%s granted=%s.',
+                self.client_id,
+                token_scopes,
+                allowed_scopes,
+                granted,
+            )
+            return granted
 
         return True
 
@@ -716,6 +780,12 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
             lti_launch_message.update({
                 "nonce": preflight_response.get("nonce")
             })
+
+            log.info(
+                'LTI 1.3 Deep Linking launch request assembled for target_link_uri=%s: claims=%s.',
+                target_link_uri,
+                redact_pii_claims(lti_launch_message),
+            )
 
             # Return new lanch message, used by XBlock to present the launch
             return {

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -28,7 +28,12 @@ from lti_consumer.lti_1p3.constants import (
     LTI_1P3_SYSTEM_ROLE_ADMINISTRATOR,
     LTI_PROCTORING_DATA_KEYS,
 )
-from lti_consumer.lti_1p3.consumer import LtiAdvantageConsumer, LtiConsumer1p3, LtiProctoringConsumer
+from lti_consumer.lti_1p3.consumer import (
+    LtiAdvantageConsumer,
+    LtiConsumer1p3,
+    LtiProctoringConsumer,
+    redact_pii_claims,
+)
 from lti_consumer.lti_1p3.deep_linking import LtiDeepLinking
 from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredClaim
 from lti_consumer.lti_1p3.nprs import LtiNrps
@@ -300,6 +305,35 @@ class TestLti1p3Consumer(TestCase):
 
         self.assertEqual(actual_output, expected_output)
         self.assertCountEqual(actual_roles, expected_roles)
+
+    @patch('lti_consumer.lti_1p3.consumer.log')
+    def test_launch_message_log_redacts_pii(self, mock_log):
+        """
+        Check that the assembled launch message is logged with learner PII redacted.
+
+        The launch message is logged in full so tool-integration problems can be diagnosed from
+        the logs, which means the name/email claims must be scrubbed before they get there.
+        """
+        self._setup_lti_launch_data()
+        self.lti_consumer.set_user_data(
+            user_id="1",
+            role="student",
+            full_name="Ada Lovelace",
+            email_address="ada@example.com",
+        )
+        self._get_lti_message()
+
+        launch_log = next(
+            call for call in mock_log.info.call_args_list
+            if 'launch request assembled' in call.args[0]
+        )
+        logged_claims = launch_log.args[-1]
+
+        self.assertEqual(logged_claims['name'], '<redacted>')
+        self.assertEqual(logged_claims['email'], '<redacted>')
+        # Non-PII claims are still there, which is the point of logging the message.
+        self.assertEqual(logged_claims['sub'], "1")
+        self.assertIn('https://purl.imsglobal.org/spec/lti/claim/message_type', logged_claims)
 
     def test_check_no_user_data_error(self):
         """
@@ -712,6 +746,62 @@ class TestLti1p3Consumer(TestCase):
         """
         with self.assertRaises(ValueError):
             self.lti_consumer.set_extra_claim(test_value)
+
+
+class TestRedactPiiClaims(TestCase):
+    """
+    Unit tests for `redact_pii_claims`, which keeps launch-message logging free of learner PII.
+    """
+
+    def test_pii_claims_are_replaced(self):
+        """
+        Name, email and the other optional identity claims must never reach the logs.
+        """
+        redacted = redact_pii_claims({
+            'name': 'Ada Lovelace',
+            'email': 'ada@example.com',
+            'preferred_username': 'ada',
+            'picture': 'http://example.com/ada.png',
+        })
+
+        self.assertEqual(
+            redacted,
+            {
+                'name': '<redacted>',
+                'email': '<redacted>',
+                'preferred_username': '<redacted>',
+                'picture': '<redacted>',
+            },
+        )
+
+    def test_non_pii_claims_are_kept(self):
+        """
+        The point of logging the launch message is to see the claims, so everything that is not
+        PII is passed through untouched -- including `sub`, the opaque platform-generated user
+        identifier needed to correlate a launch with the tool's own logs.
+        """
+        claims = {
+            'sub': 'a2b4c6d8',
+            'https://purl.imsglobal.org/spec/lti/claim/message_type': 'LtiResourceLinkRequest',
+            'https://purl.imsglobal.org/spec/lti/claim/roles': ['http://purl.imsglobal.org/vocab/lis/v2/x'],
+        }
+        self.assertEqual(redact_pii_claims(claims), claims)
+
+    def test_input_is_not_mutated(self):
+        """
+        The claims dict is signed into the id_token after being logged, so redaction must not
+        touch the original.
+        """
+        claims = {'name': 'Ada Lovelace', 'sub': 'a2b4c6d8'}
+        redact_pii_claims(claims)
+        self.assertEqual(claims['name'], 'Ada Lovelace')
+
+    def test_non_dict_input_is_returned_as_is(self):
+        """
+        A log statement must not raise on an unexpected shape.
+        """
+        self.assertEqual(redact_pii_claims(None), None)
+        self.assertEqual(redact_pii_claims('not a dict'), 'not a dict')
 
 
 @ddt.ddt

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -336,6 +336,40 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         # Set sub and roles claims.
         user_id = launch_data.external_user_id if launch_data.external_user_id else launch_data.user_id
         user_role = launch_data.user_role
+
+        # custom_parameters is documented as a dict, but callers (and existing tests) also pass a
+        # list of "key=value" strings, so extract just the parameter names defensively either way.
+        custom_parameters = launch_data.custom_parameters
+        if isinstance(custom_parameters, dict):
+            custom_parameter_names = list(custom_parameters.keys())
+        elif isinstance(custom_parameters, (list, tuple)):
+            custom_parameter_names = [
+                param.split('=', 1)[0] for param in custom_parameters
+                if isinstance(param, str) and '=' in param
+            ]
+        else:
+            custom_parameter_names = []
+
+        log.info(
+            'LTI 1.3 launch data retrieved for lti_message_hint=%s: config_id=%s resource_link_id=%s '
+            'message_type=%s user_id=%s user_role=%s context_id=%s context_type=%s has_name=%s '
+            'has_email=%s has_preferred_username=%s custom_parameter_names=%s '
+            'deep_linking_content_item_id=%s.',
+            lti_message_hint,
+            config_id,
+            launch_data.resource_link_id,
+            launch_data.message_type,
+            user_id,
+            user_role,
+            launch_data.context_id,
+            launch_data.context_type,
+            bool(launch_data.name),
+            bool(launch_data.email),
+            bool(launch_data.preferred_username),
+            custom_parameter_names,
+            launch_data.deep_linking_content_item_id,
+        )
+
         lti_consumer.set_user_data(
             user_id=user_id,
             role=user_role,
@@ -382,6 +416,23 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
 
         # Retrieve preflight response.
         preflight_response = request_params.dict()
+
+        log.info(
+            # state/nonce are single-use, tool-generated correlation values (not credentials) --
+            # logging them lets a specific launch attempt be matched against the tool's own logs.
+            'LTI 1.3 authentication request (preflight response) received from tool for config_id=%s: '
+            'redirect_uri=%s client_id=%s state=%s nonce=%s response_type=%s response_mode=%s '
+            'scope=%s prompt=%s.',
+            config_id,
+            preflight_response.get('redirect_uri'),
+            preflight_response.get('client_id'),
+            preflight_response.get('state'),
+            preflight_response.get('nonce'),
+            preflight_response.get('response_type'),
+            preflight_response.get('response_mode'),
+            preflight_response.get('scope'),
+            preflight_response.get('prompt'),
+        )
 
         # Set LTI Launch URL.
         context.update({'launch_url': preflight_response.get("redirect_uri")})
@@ -457,6 +508,16 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
             'launch_url': context['launch_url']
         }
         track_event('xblock.launch_request', event)
+
+        log.info(
+            'LTI 1.3 launch handed off to browser for config_id=%s resource_link_id=%s user_id=%s '
+            'launch_url=%s: Open edX finished building the launch successfully; any failure past this '
+            "point happens in the browser-to-tool POST and on the tool's own server, outside these logs.",
+            config_id,
+            launch_data.resource_link_id,
+            user_id,
+            context['launch_url'],
+        )
 
         return render(request, 'html/lti_1p3_launch.html', context)
     except Lti1p3Exception as exc:
@@ -765,6 +826,60 @@ def deep_linking_content_endpoint(request, lti_config_id):
     })
 
 
+# Fields that may carry PII or arbitrary tool-supplied free text (a persistent external user
+# identifier, and a free-text comment). Logged as a length only, never their content -- the rest
+# of the AGS fields are grading metadata (scores, progress enums, resource ids) safe to log as-is.
+_AGS_REDACTED_LOG_FIELDS = frozenset({'userId', 'comment'})
+
+
+def _truncate_for_log(value, max_len=200):
+    """
+    Stringify and truncate `value` to `max_len` characters, so a malformed or oversized
+    tool-supplied value can't blow up a log line.
+    """
+    return str(value)[:max_len]
+
+
+def _ags_field_value(payload, field, max_len=200):
+    """
+    Return a log-safe representation of `field` from an AGS request payload.
+
+    Truncated to `max_len` characters so a malformed or oversized tool-supplied payload can't
+    blow up the log line, and with newlines/carriage returns escaped so a tool-supplied value
+    can't be used to forge additional, fake-looking log lines. Returns 'n/a' if the payload
+    doesn't support key lookup, and 'missing' if the key is absent entirely -- as opposed to an
+    explicit `null`, which is returned as the string 'None' so the two remain distinguishable in
+    the log (e.g. an AGS "erase score" request explicitly nulls `scoreGiven` rather than omitting
+    it). See `_AGS_REDACTED_LOG_FIELDS` for fields logged as a length only.
+    """
+    if not hasattr(payload, 'get'):
+        return 'n/a'
+    if field not in payload:
+        return 'missing'
+    value = payload.get(field)
+    if field in _AGS_REDACTED_LOG_FIELDS:
+        return 'n/a' if value is None else f'<{len(str(value))} chars>'
+    text = _truncate_for_log(value, max_len)
+    return text.replace('\n', '\\n').replace('\r', '\\r')
+
+
+def _summarize_ags_error(response_data, max_len=200):
+    """
+    Build a short, log-safe summary of a DRF AGS error response body: for each
+    top-level key, the first error message truncated, so a malformed or huge
+    tool-supplied payload can't blow up the log line.
+    """
+    if isinstance(response_data, dict):
+        summary = {}
+        for key, value in response_data.items():
+            if isinstance(value, (list, tuple)) and value:
+                summary[key] = _truncate_for_log(value[0], max_len)
+            else:
+                summary[key] = _truncate_for_log(value, max_len)
+        return summary
+    return _truncate_for_log(response_data, max_len)
+
+
 class LtiAgsLineItemViewset(viewsets.ModelViewSet):
     """
     LineItem endpoint implementation from LTI Advantage.
@@ -793,6 +908,61 @@ class LtiAgsLineItemViewset(viewsets.ModelViewSet):
         'resource_id',
         'tag'
     ]
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Log a structured summary of every incoming LTI AGS request (line item
+        list/create/read/update/delete, score submission, result retrieval)
+        before authentication/permission checks run, so the request is logged
+        even when the tool's credentials or payload turn out to be invalid.
+        """
+        lti_config_id = self.kwargs.get('lti_config_id')
+        line_item_id = self.kwargs.get('pk')
+        payload = request.data if request.method in ('POST', 'PUT', 'PATCH') else request.query_params
+
+        log.info(
+            'LTI AGS request received: action=%s method=%s lti_config_id=%s line_item_id=%s '
+            'payload_keys=%s resourceId=%s resourceLinkId=%s scoreMaximum=%s userId=%s '
+            'scoreGiven=%s activityProgress=%s gradingProgress=%s comment=%s timestamp=%s.',
+            self.action,
+            request.method,
+            lti_config_id,
+            line_item_id,
+            list(payload.keys()) if hasattr(payload, 'keys') else [],
+            _ags_field_value(payload, 'resourceId'),
+            _ags_field_value(payload, 'resourceLinkId'),
+            _ags_field_value(payload, 'scoreMaximum'),
+            _ags_field_value(payload, 'userId'),
+            _ags_field_value(payload, 'scoreGiven'),
+            _ags_field_value(payload, 'activityProgress'),
+            _ags_field_value(payload, 'gradingProgress'),
+            _ags_field_value(payload, 'comment'),
+            _ags_field_value(payload, 'timestamp'),
+        )
+
+        super().initial(request, *args, **kwargs)
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        """
+        Log the outcome of every LTI AGS request (status code, and error
+        keys/messages when the response is an error) so a failed tool
+        integration call can be matched against what was logged in `initial`.
+        """
+        response = super().finalize_response(request, response, *args, **kwargs)
+
+        is_error = response.status_code >= 400
+        log.info(
+            'LTI AGS response returned: action=%s method=%s lti_config_id=%s line_item_id=%s '
+            'status_code=%s error=%s.',
+            getattr(self, 'action', None),
+            request.method,
+            self.kwargs.get('lti_config_id'),
+            self.kwargs.get('pk'),
+            response.status_code,
+            _summarize_ags_error(response.data) if is_error else None,
+        )
+
+        return response
 
     def get_queryset(self):
         lti_configuration = self.request.lti_configuration

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from rest_framework.test import APITransactionTestCase
 
 from lti_consumer.lti_xblock import LtiConsumerXBlock
+from lti_consumer.plugin.views import _ags_field_value, _summarize_ags_error
 from lti_consumer.models import LtiAgsLineItem, LtiAgsScore, LtiConfiguration
 from lti_consumer.tests.test_utils import TestBaseWithPatch, make_xblock
 
@@ -80,6 +81,73 @@ class LtiAgsLineItemViewSetTestCase(APITransactionTestCase, TestBaseWithPatch):
         )
 
 
+class LtiAgsLogHelpersTest(TestBaseWithPatch):
+    """
+    Test the log-sanitizing helpers used by `LtiAgsLineItemViewset` request/response logging.
+    """
+
+    def test_ags_field_value_distinguishes_absent_from_null(self):
+        """
+        An absent key and an explicit `null` must not look the same in the log: an AGS
+        "erase score" request nulls `scoreGiven` rather than omitting it, and that difference
+        is what a reader of the log needs to see.
+        """
+        self.assertEqual(_ags_field_value({}, 'scoreGiven'), 'missing')
+        self.assertEqual(_ags_field_value({'scoreGiven': None}, 'scoreGiven'), 'None')
+
+    def test_ags_field_value_logs_zero(self):
+        """
+        A `scoreGiven` of 0 must be logged as 0, not swallowed by a falsy check.
+        """
+        self.assertEqual(_ags_field_value({'scoreGiven': 0}, 'scoreGiven'), '0')
+
+    def test_ags_field_value_redacts_pii_fields_to_a_length(self):
+        """
+        `userId` and `comment` can carry a persistent user identifier and arbitrary tool-supplied
+        free text, so only their length is logged.
+        """
+        self.assertEqual(_ags_field_value({'userId': 'abc123'}, 'userId'), '<6 chars>')
+        self.assertEqual(_ags_field_value({'comment': 'nice work'}, 'comment'), '<9 chars>')
+        self.assertEqual(_ags_field_value({'comment': None}, 'comment'), 'n/a')
+
+    def test_ags_field_value_escapes_newlines(self):
+        """
+        A tool-supplied value must not be able to forge extra log lines.
+        """
+        self.assertEqual(
+            _ags_field_value({'resourceId': 'real\nFAKE LOG LINE'}, 'resourceId'),
+            'real\\nFAKE LOG LINE',
+        )
+
+    def test_ags_field_value_truncates(self):
+        """
+        An oversized tool-supplied value must not blow up the log line.
+        """
+        self.assertEqual(len(_ags_field_value({'resourceId': 'x' * 500}, 'resourceId')), 200)
+
+    def test_ags_field_value_handles_non_mapping_payload(self):
+        """
+        `initial()` passes whatever the request carries; a payload with no key lookup is not an
+        error worth raising from a log statement.
+        """
+        self.assertEqual(_ags_field_value(['not', 'a', 'mapping'], 'scoreGiven'), 'n/a')
+
+    def test_summarize_ags_error_takes_first_message_per_key(self):
+        """
+        DRF error bodies map a field to a list of messages; the log needs the field names and a
+        representative message, not the whole structure.
+        """
+        summary = _summarize_ags_error({'scoreMaximum': ['is required', 'and must be positive']})
+        self.assertEqual(summary, {'scoreMaximum': 'is required'})
+
+    def test_summarize_ags_error_truncates_and_handles_non_dict(self):
+        """
+        Same oversized-payload protection as `_ags_field_value`, for error bodies of any shape.
+        """
+        self.assertEqual(len(_summarize_ags_error({'detail': ['x' * 500]})['detail']), 200)
+        self.assertEqual(_summarize_ags_error('plain string error'), 'plain string error')
+
+
 @ddt.ddt
 class LtiAgsViewSetTokenTests(LtiAgsLineItemViewSetTestCase):
     """
@@ -121,6 +189,56 @@ class LtiAgsViewSetTokenTests(LtiAgsLineItemViewSetTestCase):
         self._set_lti_token()
         response = self.client.get(self.lineitem_endpoint)
         self.assertEqual(response.status_code, 403)
+
+    @patch('lti_consumer.lti_1p3.consumer.log')
+    @patch('lti_consumer.plugin.views.log')
+    def test_denied_request_is_logged_with_a_reason(self, views_log, consumer_log):
+        """
+        A 403 must be explainable from the logs alone: the request is logged before
+        authentication runs, and the denial reason is logged by the scope check.
+
+        This is the case the logging exists for -- previously a tool integration failing here
+        produced only an access log line with a status code and no indication of why.
+        """
+        self._set_lti_token()
+
+        response = self.client.get(self.lineitem_endpoint)
+
+        self.assertEqual(response.status_code, 403)
+
+        views_output = ' '.join(str(call) for call in views_log.info.call_args_list)
+        self.assertIn('LTI AGS request received', views_output)
+        self.assertIn('LTI AGS response returned', views_output)
+        self.assertIn('403', views_output)
+
+        # The scope check says why, naming what was required versus what the token granted.
+        # Log arguments are left unformatted by design, so assert on them rather than the message.
+        scope_warning = consumer_log.warning.call_args
+        self.assertIn('LTI 1.3 token scope check', scope_warning.args[0])
+        self.assertFalse(scope_warning.args[-1])
+        required_scopes = scope_warning.args[-2]
+        self.assertIn('https://purl.imsglobal.org/spec/lti-ags/scope/lineitem', required_scopes)
+
+    @patch('lti_consumer.plugin.views.log')
+    def test_accepted_request_is_logged_with_its_outcome(self, views_log):
+        """
+        An accepted request logs the same request/response pair, with no error summary.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly')
+
+        response = self.client.get(self.lineitem_endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        views_output = ' '.join(str(call) for call in views_log.info.call_args_list)
+        self.assertIn('LTI AGS request received', views_output)
+        self.assertIn('LTI AGS response returned', views_output)
+        # `error` is the last positional argument of the response log line.
+        response_log = next(
+            call for call in views_log.info.call_args_list
+            if 'LTI AGS response returned' in str(call.args[0])
+        )
+        self.assertEqual(response_log.args[-2], 200)
+        self.assertIsNone(response_log.args[-1])
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description

When an LTI Advantage AGS call fails with a `403`, today's logs show the endpoint and the status code and nothing else. They do not say whether the cause was a missing scope, an LTI config mismatch, a resource link mismatch, line item ownership, or an XBlock lookup failure. The launch flow is similarly opaque — a launch that succeeds on the platform side and then fails at the tool leaves no trace of what was actually sent.

This adds logging along both paths:

**Launch** — OIDC launch start, the OIDC login redirect, the preflight response received back from the tool, the assembled launch message (both resource link and deep linking), and the final hand-off to the browser. That last one is explicit that anything failing past it happens in the browser-to-tool POST and on the tool's own server, outside these logs.

**Tokens** — access token issuance, recording requested versus granted scopes, and every token scope check. The scope check logs at `WARNING` when it denies the request, naming the required scopes against those the token actually carries. In our experience this is the single most common cause of an otherwise unexplained AGS `403`.

**AGS** — every request logged from `initial()`, which runs *before* authentication so a request with bad credentials is logged too, and every outcome logged from `finalize_response()` with the error keys and messages summarized. The two lines share `action`/`method`/`lti_config_id`/`line_item_id` so a failed call can be matched up.

### Safety

Per the issue, these logs are meant to be safe to emit in production:

- No JWTs, access tokens or client assertions are logged.
- Learner PII is kept out: the `name`, `email` and `preferred_username` launch claims are replaced with `<redacted>` before the launch message is logged, and the AGS `userId` and `comment` fields are logged as a length only (`<6 chars>`). `sub` is kept — it is an opaque, platform-generated identifier and is the only way to correlate a launch with the tool's own logs.
- Tool-supplied values are truncated to 200 characters and have newlines escaped, so a malformed or hostile payload cannot bloat a log line or forge a fake-looking one.
- An absent AGS field logs as `missing` and an explicit `null` logs as `None`, so the two stay distinguishable — an AGS "erase score" request nulls `scoreGiven` rather than omitting it.

## Fixes

Fixes #671

## Testing

New tests cover the sanitizing logic and the two scenarios the issue calls out:

- `LtiAgsLogHelpersTest` — absent versus explicit `null`, a `scoreGiven` of `0`, `userId`/`comment` redaction, newline escaping, truncation, non-mapping payloads, and DRF error-body summarizing.
- `test_denied_request_is_logged_with_a_reason` — a `403` is explainable from the logs alone: the request is logged, the response is logged with its status, and the scope check names required versus granted.
- `test_accepted_request_is_logged_with_its_outcome` — an accepted request logs status `200` and no error.
- `TestRedactPiiClaims` plus `test_launch_message_log_redacts_pii` — PII claims are scrubbed, non-PII claims survive, and the original claims dict is not mutated before it is signed into the `id_token`.

Full suite (780 tests) passes; `pycodestyle` and `pylint` clean.

## Credit

The bulk of this logging was written by Imran Bashir and extended by Syed Sajjad Hussain Shah while debugging live tool integrations; this PR ports that work to master, adds tests, and adds the PII redaction described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
