### PR TITLE
backport: LTI 1.3 and LTI Advantage fixes for Ulmo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,22 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.15.1 - 2026-08-27
+-------------------
+* Fix LTI version conflicts for external (reusable) configs: resolve the
+  effective LTI version from the external config throughout XBlock runtime
+  paths (launch, access token, outcomes, context) instead of trusting a
+  possibly stale block-level ``lti_version`` field.
+* Studio editor: hide the ``LTI Version`` field and show the
+  ``LTI Reusable Configuration ID`` field when Configuration Type is set to
+  "Reusable Configuration", and vice versa for "Configuration on block" /
+  "Database Configuration", so the editor never shows an editable field
+  that has no effect.
+* Note: upstream PR #663 additionally reworked the Studio editor around a
+  multi-step wizard (openedx#650) with live AJAX version resolution as you
+  type a reusable config ID; this branch keeps its existing flat editor, so
+  only the show/hide behavior above was ported, not the live preview.
+
 9.15.0 - 2026-08-27
 -------------------
 * Update LTI 1.3 launch and NRPS role mapping to use context role URIs.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,8 +21,19 @@ Unreleased
 * Publish AGS scores with a ``scoreGiven`` of ``0`` to the LMS gradebook. The
   grade publishing signal tested ``scoreGiven`` for truthiness, so a valid zero
   score was treated as a missing one and never reached the gradebook.
-* Require ``scoreMaximum`` when ``scoreGiven`` is ``0``, which the ``LtiAgsScore``
-  model validation skipped for the same reason.
+* Reject a ``scoreMaximum`` that is unset or not positive whenever ``scoreGiven``
+  is present, in both ``LtiAgsScore.clean()`` and the AGS score serializer. Both
+  had the same truthiness bug, and a ``scoreMaximum`` of ``0`` is not a usable
+  denominator: it could be saved through the ORM or admin, was then silently
+  skipped by the publishing signal, yet was still reported as a successful result
+  by ``LtiAgsResultSerializer``.
+* Report an LTI 1.1 ``module_score`` of ``0`` from the result service instead of
+  omitting it, which reported a learner scored zero as ungraded.
+* Log the reason a grade publish was skipped -- grading progress, resource link id,
+  score given/maximum, and the block's ``has_score``/past-due state -- instead of
+  only ever logging a successful publish.
+
+  Matches upstream PR #701 (issue #695).
 
 9.16.0 - 2026-08-27
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.16.1 - 2026-09-10
+-------------------
+* Publish AGS scores with a ``scoreGiven`` of ``0`` to the LMS gradebook. The
+  grade publishing signal tested ``scoreGiven`` for truthiness, so a valid zero
+  score was treated as a missing one and never reached the gradebook.
+* Require ``scoreMaximum`` when ``scoreGiven`` is ``0``, which the ``LtiAgsScore``
+  model validation skipped for the same reason.
+
 9.16.0 - 2026-08-27
 -------------------
 * Add pagination support to the NRPS ``/context_membership`` endpoint, accepting

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.14.4 - 2026-08-25
+-------------------
+* Fix LTI 1.3 deep linking `target_link_uri` handling in both preflight and launch token generation.
+* Fix AGS results endpoint/serializer URL generation for optional `user_id`, including trailing-slash compatibility.
+* Allow AGS score `comment` to be blank and improve related API test coverage.
+* Use `get_lti_consumer()` OAuth credentials for LTI 1.1 signature/logging paths and align LTI 1.1 errors with shared `LtiError`.
+* Minor internal cleanup: public `get_lti_consumer()` rename, launch URL typing/casting, and fallback to block `lti_version` when config version is missing.
+
 9.14.2 - 2025-08-06
 -------------------
 * Deprecation/Removal of pyjwkest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.16.0 - 2026-08-27
+-------------------
+* Add pagination support to the NRPS ``/context_membership`` endpoint, accepting
+  ``limit`` and ``page`` query parameters with RFC 8288 ``Link`` headers for
+  continuation.
+
 9.15.2 - 2026-08-27
 -------------------
 * Fix LTI 1.3 deep linking launches to POST the ``id_token`` to the tool-provided ``redirect_uri``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.15.0 - 2026-08-27
+-------------------
+* Update LTI 1.3 launch and NRPS role mapping to use context role URIs.
+* Include supported forum roles like `Community TA` and `Group Moderator` in LTI 1.3 launches and NRPS membership responses.
+* Add ADR documenting updated LTI 1.3 role mapping behavior.
+
 9.14.4 - 2026-08-25
 -------------------
 * Fix LTI 1.3 deep linking `target_link_uri` handling in both preflight and launch token generation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.15.2 - 2026-08-27
+-------------------
+* Fix LTI 1.3 deep linking launches to POST the ``id_token`` to the tool-provided ``redirect_uri``
+  rather than the platform-configured ``deep_linking_launch_url``. Per
+  `IMS Security Framework §5.1.1.3 <https://www.imsglobal.org/spec/security/v1p0#step-3-authentication-response>`_
+  and `LTI Deep Linking 2.0 §2.1 <https://www.imsglobal.org/spec/lti-dl/v2p0#redirection-from-platform-to-tool>`_,
+  the OIDC authentication response must always POST to ``redirect_uri``; ``deep_linking_launch_url``
+  belongs in the JWT as ``target_link_uri`` only.
+
 9.15.1 - 2026-08-27
 -------------------
 * Fix LTI version conflicts for external (reusable) configs: resolve the

--- a/docs/decisions/0002-lti-1p3-variables.rst
+++ b/docs/decisions/0002-lti-1p3-variables.rst
@@ -39,31 +39,8 @@ See http://www.imsglobal.org/spec/lti/v1p3/#single-tenant-tool-registered-and-de
 
 Roles
 ~~~~~
-The roles claim takes in a list of LTI 1.3 compliant roles from http://www.imsglobal.org/spec/lti/v1p3/#role-vocabularies.
-The claim name is: https://purl.imsglobal.org/spec/lti/claim/roles.
-
-The mappings from Open edX roles are shown in the table below:
-
-.. list-table::
-   :widths: auto
-   :header-rows: 1
-
-   * - Open edX role
-     - LTI 1.3 Roles included
-     - Reasoning
-   * - guest
-     - Empty
-     - Guests users are not logged in, they shouldn't be able to access LTI content.
-   * - student
-     - 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student'
-     - Students only have permission to view and interact with the LTI content.
-   * - instructor
-     - 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor'
-     - Instructor have both instructor and student access to a tool. No admin permissions.
-   * - staff
-     - 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator'
-       'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor'
-     - A staff user should be able to modify the tool settings and have full access to the content and settings.
+Current source of truth for roles mapping is
+`0008-lti-1p3-role-mapping-update.rst <0008-lti-1p3-role-mapping-update.rst>`_.
 
 Resource link
 ~~~~~~~~~~~~~

--- a/docs/decisions/0008-lti-1p3-role-mapping-update.rst
+++ b/docs/decisions/0008-lti-1p3-role-mapping-update.rst
@@ -1,0 +1,179 @@
+LTI 1.3 roles mapping update
+----------------------------
+
+Status
+======
+
+Provisional
+
+Context
+=======
+
+Open edX LTI 1.3 launch code historically mapped course roles to institution and system role URIs.
+This caused interoperability problems with tools that expect context role URIs in LTI launch and NRPS
+membership responses.
+
+LTI 1.3 roles claim allows role URIs from published LIS vocabularies, including:
+
+* system roles
+* institution roles
+* context roles
+
+In practice, LTI launches in Open edX happen in course context, so context roles are most relevant.
+Open edX also has more explicit role values than ``staff``, ``instructor``, ``student``, and ``guest``.
+These include course roles such as ``limited_staff``, ``finance_admin``, ``sales_admin``,
+``beta_testers``, ``library_user``, ``ccx_coach``, and ``data_researcher``.
+Open edX also defines discussion roles such as ``Administrator``, ``Moderator``,
+``Group Moderator``, ``Community TA``, and ``Student``.
+Global Django staff (``user.is_staff``) is represented in LTI mapping as ``global_staff``.
+
+This ADR records updated mapping used for:
+
+* LTI 1.3 launch roles claim
+* LTI NRPS membership container member roles
+
+This ADR supersedes Roles section from
+`0002-lti-1p3-variables.rst <0002-lti-1p3-variables.rst>`_.
+
+Decisions
+=========
+
+Launch roles claim
+~~~~~~~~~~~~~~~~~~
+
+For LTI launches, Open edX includes context role URIs plus neutral system and institution role URIs:
+
+* ``http://purl.imsglobal.org/vocab/lis/v2/system/person#None``
+* ``http://purl.imsglobal.org/vocab/lis/v2/institution/person#None``
+
+Context role mapping is shown below.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - Open edX role
+     - LTI 1.3 roles included
+     - Reasoning
+   * - instructor
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Administrator``
+       ``membership#Instructor``
+     - Course admin role in Open edX maps to highest course-context privilege.
+   * - global_staff
+     - ``system/person#Administrator``
+       ``institution/person#Administrator``
+       ``institution/person#Staff``
+       ``institution/person#Faculty``
+       ``institution/person#Instructor``
+       ``membership#Administrator``
+       ``membership#Instructor``
+     - Global Django staff maps to instance-admin style LIS roles for tool launches.
+   * - staff
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Instructor``
+     - Course staff should have instructor-level context access, but not course admin role.
+   * - limited_staff
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Instructor``
+     - Limited staff derives from staff and should expose same course-context role to tools.
+   * - student
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Standard learner mapping.
+   * - guest
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Guest launch paths use learner-compatible mapping for interoperability.
+   * - finance_admin
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - sales_admin
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - beta_testers
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - library_user
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - ccx_coach
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - data_researcher
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - No stronger LTI-specific course-context privilege required.
+   * - org_course_creator_group
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Org-scoped role does not imply elevated privilege in specific course launch context.
+   * - course_creator_group
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Platform-wide role does not imply elevated privilege in specific course launch context.
+   * - support
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Support role should not expose elevated course-context privilege to tools by default.
+   * - Administrator, Moderator, Student
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+     - Discussion roles do not map cleanly to elevated LTI course-context privilege, so default to learner.
+   * - Group Moderator, Community TA
+     - ``system/person#None``
+       ``institution/person#None``
+       ``membership#Learner``
+       ``membership#TeachingAssistant``
+     - These discussion roles align with teaching-assistant style participation in course context.
+
+NRPS membership roles
+~~~~~~~~~~~~~~~~~~~~~
+
+For NRPS membership responses, Open edX includes context roles only.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - Open edX role
+     - NRPS roles included
+   * - instructor
+     - ``membership#Administrator`` ``membership#Instructor``
+   * - global_staff
+     - ``membership#Administrator`` ``membership#Instructor``
+   * - staff
+     - ``membership#Instructor``
+   * - limited_staff
+     - ``membership#Instructor``
+   * - Group Moderator, Community TA
+     - ``membership#Learner`` ``membership#TeachingAssistant``
+   * - all other explicitly mapped roles
+     - ``membership#Learner``
+
+Consequences
+============
+
+* Tool compatibility improves because context role URIs are now present in launch and NRPS flows.
+* Open edX role handling becomes explicit for current known course, org, and global staff values.
+* Older documentation in ``0002-lti-1p3-variables.rst`` remains historical and should not be treated as current source of truth for roles mapping.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.14.3'
+__version__ = '9.14.4'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.15.0'
+__version__ = '9.15.1'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.16.0'
+__version__ = '9.16.1'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.15.2'
+__version__ = '9.16.0'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.15.1'
+__version__ = '9.15.2'

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.14.4'
+__version__ = '9.15.0'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -142,6 +142,7 @@ def get_lti_1p3_launch_info(
 
     config_id = lti_config.config_id
     client_id = lti_config.lti_1p3_client_id
+    deployment_id = "1"
 
     # Display LTI launch information from external configuration.
     # if an external configuration is being used.
@@ -149,12 +150,13 @@ def get_lti_1p3_launch_info(
         external_config = get_external_config_from_filter({}, lti_config.external_id)
         config_id = lti_config.external_id.replace(':', '/')
         client_id = external_config.get('lti_1p3_client_id')
+        deployment_id = external_config.get('lti_1p3_deployment_id', deployment_id)
 
     # Return LTI launch information for end user configuration
     return {
         'client_id': client_id,
         'keyset_url': get_lms_lti_keyset_link(config_id),
-        'deployment_id': '1',
+        'deployment_id': deployment_id,
         'oidc_callback': get_lms_lti_launch_link(),
         'token_url': get_lms_lti_access_token_link(config_id),
         'deep_linking_launch_url': deep_linking_launch_url,

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -74,7 +74,8 @@ def _get_lti_config_for_block(block):
             block.external_config
         )
         lti_config = _get_or_create_local_lti_config(
-            config.get("version"),
+            # fallback on block lti_version if the external config does not provide one
+            config.get("version") or block.lti_version,
             block.scope_ids.usage_id,
             LtiConfiguration.CONFIG_EXTERNAL,
             external_id=block.external_config,

--- a/lti_consumer/data.py
+++ b/lti_consumer/data.py
@@ -52,8 +52,9 @@ class Lti1p3LaunchData:
         attribute external_user_id is provided, user_id will only be used internally and will not be shared externally.
         If external_user_id is not provided, user_id will be shared externally, and then it must be stable to the
         issuer.
-    * user_role (required): The user's role as one of the keys in LTI_1P3_ROLE_MAP: staff, instructor, student, or
-        guest. It can also be None if the empty list should be sent in the LTI launch message.
+    * user_role (required): The user's role as one of the keys in LTI_1P3_ROLE_MAP, including Open edX course and
+        org role names explicitly supported by this package. It can also be None if the empty list should be sent in
+        the LTI launch message.
     * config_id (required): The config_id field of an LtiConfiguration to use for the launch.
     * resource_link_id (required): A unique identifier that is guaranteed to be unique for each placement of the LTI
         link.

--- a/lti_consumer/lti_1p1/exceptions.py
+++ b/lti_consumer/lti_1p1/exceptions.py
@@ -1,9 +1,10 @@
 """
 Exceptions for the LTI1.1 Consumer.
 """
+from lti_consumer.exceptions import LtiError
 
 
-class Lti1p1Error(Exception):
+class Lti1p1Error(LtiError):
     """
     General error class for LTI1.1 Consumer usage.
     """

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -7,7 +7,6 @@ LTI message generation and validation.
 """
 from enum import Enum
 
-
 LTI_BASE_MESSAGE = {
     # Claim type: fixed key with value `LtiResourceLinkRequest`
     # http://www.imsglobal.org/spec/lti/v1p3/#message-type-claim
@@ -18,34 +17,91 @@ LTI_BASE_MESSAGE = {
     "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
 }
 
+# Role mappings
+# Values follow proposed mapping in role matrix.
+LTI_1P3_ROLE_BASE = [
+    'http://purl.imsglobal.org/vocab/lis/v2/system/person#None',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#None',
+]
+
+LTI_1P3_CONTEXT_ROLE_INSTRUCTOR = [
+    'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor',
+]
+
+LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR = [
+    'http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator',
+    'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor',
+]
+
+LTI_1P3_SYSTEM_ROLE_ADMINISTRATOR = [
+    'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator',
+]
+
+LTI_1P3_INSTITUTION_ROLE_ADMINISTRATOR = [
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
+]
+
+LTI_1P3_CONTEXT_ROLE_LEARNER = [
+    'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner',
+]
+
+LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT = [
+    'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant',
+]
+
 LTI_1P3_ROLE_MAP = {
-    'staff': [
-        'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator',
-        'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
-    ],
-    'instructor': [
-        'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
-    ],
-    'student': [
-        'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student'
-    ],
-    'guest': [
-        'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student'
-    ],
+    'global_staff': (
+        LTI_1P3_SYSTEM_ROLE_ADMINISTRATOR +
+        LTI_1P3_INSTITUTION_ROLE_ADMINISTRATOR +
+        LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR
+    ),
+    'staff': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    'limited_staff': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    'instructor': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
+    'student': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'guest': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'finance_admin': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'sales_admin': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'beta_testers': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'library_user': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'ccx_coach': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'data_researcher': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'org_course_creator_group': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'course_creator_group': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'support': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Administrator': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Moderator': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Group Moderator': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+    'Community TA': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+    'Student': LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER,
 }
 
-# Context membership roles
+# Context membership roles (kept for callers using context map directly)
 # https://www.imsglobal.org/spec/lti/v1p3/#lis-vocabulary-for-context-roles
 LTI_1P3_CONTEXT_ROLE_MAP = {
-    'staff': [
-        'http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator',
-    ],
-    'instructor': [
-        'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor',
-    ],
-    'student': [
-        'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner',
-    ],
+    'global_staff': LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
+    'staff': LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    'limited_staff': LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    'instructor': LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
+    'student': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'guest': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'finance_admin': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'sales_admin': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'beta_testers': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'library_user': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'ccx_coach': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'data_researcher': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'org_course_creator_group': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'course_creator_group': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'support': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Administrator': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Moderator': LTI_1P3_CONTEXT_ROLE_LEARNER,
+    'Group Moderator': LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+    'Community TA': LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+    'Student': LTI_1P3_CONTEXT_ROLE_LEARNER,
 }
 
 LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS = {

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -77,6 +77,15 @@ class LtiConsumer1p3:
         # Extra claims - used by LTI Advantage
         self.extra_claims = {}
 
+    def _get_target_link_uri(self, launch_data):  # pylint: disable=unused-argument
+        """
+        Return the target_link_uri to use for the provided launch data.
+
+        Subclasses can override this to customize the target link selection for
+        different message types.
+        """
+        return self.launch_url
+
     @staticmethod
     def _get_user_roles(role):
         """
@@ -125,12 +134,14 @@ class LtiConsumer1p3:
 
         oidc_url = self.oidc_url + "?"
 
+        target_link_uri = self._get_target_link_uri(launch_data)
+
         login_hint = user_id
         parameters = {
             "iss": self.iss,
             "client_id": self.client_id,
             "lti_deployment_id": self.deployment_id,
-            "target_link_uri": self.launch_url,
+            "target_link_uri": target_link_uri,
             "login_hint": login_hint,
             "lti_message_hint": launch_data_key,
         }
@@ -302,6 +313,7 @@ class LtiConsumer1p3:
     def get_lti_launch_message(
             self,
             include_extra_claims=True,
+            target_link_uri=None,
     ):
         """
         Build LTI message from class parameters
@@ -311,6 +323,8 @@ class LtiConsumer1p3:
         """
         # Start from base message
         lti_message = LTI_BASE_MESSAGE.copy()
+
+        target_link_uri = target_link_uri or self.launch_url
 
         # Add base parameters
         lti_message.update({
@@ -329,7 +343,7 @@ class LtiConsumer1p3:
             # Target Link URI: actual endpoint for the LTI resource to display
             # MUST be the same value as the target_link_uri passed by the platform in the OIDC login request
             # http://www.imsglobal.org/spec/lti/v1p3/#target-link-uri
-            "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": self.launch_url,
+            "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": target_link_uri,
         })
 
         # Check if user data is set, then append it to lti message
@@ -609,6 +623,19 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
         else:
             return False
 
+    def _get_target_link_uri(self, launch_data):
+        """
+        Use the deep linking launch URL for deep linking requests.
+        """
+        if (
+            getattr(self, 'dl', None) and
+            launch_data and
+            getattr(launch_data, 'message_type', None) == 'LtiDeepLinkingRequest'
+        ):
+            return self.dl.deep_linking_launch_url
+
+        return super()._get_target_link_uri(launch_data)
+
     def enable_ags(
         self,
         lineitems_url,
@@ -663,12 +690,14 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
         # Check if Deep Linking is enabled and that this is a Deep Link Launch
         if self.dl and launch_data.message_type == "LtiDeepLinkingRequest":
+            target_link_uri = self._get_target_link_uri(launch_data)
             # Validate preflight response
             self._validate_preflight_response(preflight_response)
 
             # Get LTI Launch Message
             lti_launch_message = self.get_lti_launch_message(
                 include_extra_claims=False,
+                target_link_uri=target_link_uri,
             )
 
             # Update message type to LtiDeepLinkingRequest,

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -94,10 +94,11 @@ class LtiConsumer1p3:
         Used in roles claim: should return array of URI values
         for roles that the user has within the message's context.
 
-        Supported roles:
-        * Core - Administrator
-        * Institution - Instructor (non-core role)
-        * Institution - Student
+        Supported mappings:
+        * instructor -> membership Administrator + Instructor, system None, institution None
+        * staff/limited_staff -> membership Instructor, system None, institution None
+        * student/guest, discussion roles, and other explicit Open edX roles -> membership Learner,
+          system None, institution None
 
         Reference: http://www.imsglobal.org/spec/lti/v1p3/#roles-claim
         Role vocabularies: http://www.imsglobal.org/spec/lti/v1p3/#role-vocabularies

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -346,16 +346,16 @@ class LtiConsumer1p3:
         else:
             raise ValueError("Required resource_link data isn't set.")
 
+        # Context claim
+        if self.lti_claim_context:
+            lti_message.update(self.lti_claim_context)
+
         # Only used when doing normal LTI launches
         if include_extra_claims:
             # Set optional claims
             # Launch presentation claim
             if self.lti_claim_launch_presentation:
                 lti_message.update(self.lti_claim_launch_presentation)
-
-            # Context claim
-            if self.lti_claim_context:
-                lti_message.update(self.lti_claim_context)
 
             # Platform instance claim
             # The GUID must be consistent across platform deployments, so we have opted to generate a UUID

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -1,23 +1,23 @@
 """
 Serializers for LTI-related endpoints
 """
+import urllib.parse
 from datetime import timezone
-from rest_framework import serializers, ISO_8601
-from rest_framework.reverse import reverse
+
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
+from rest_framework import ISO_8601, serializers
+from rest_framework.reverse import reverse
 
-from lti_consumer.models import LtiAgsLineItem, LtiAgsScore
 from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_ROLE_MAP
+from lti_consumer.models import LtiAgsLineItem, LtiAgsScore
 
 
-class UsageKeyField(serializers.Field):
+class EncodedUsageKeyField(serializers.Field):
     """
-    Serializer field for a model UsageKey field.
-
-    Recreated here since we cannot import directly from
-    from the platform like so:
-    `from openedx.core.lib.api.serializers import UsageKeyField`
+    This serializer field converts from a form of encoded usage key
+    to an instance of UsageKey. This is useful for LTI request parameters,
+    where it may be necessary to encode a usage key which includes + in the string.
     """
     def to_representation(self, value):
         """
@@ -27,12 +27,15 @@ class UsageKeyField(serializers.Field):
 
     def to_internal_value(self, data):
         """
-        Convert unicode to a usage key.
+        Convert encoded unicode to a usage key.
         """
         try:
             return UsageKey.from_string(data)
-        except InvalidKeyError as err:
-            raise serializers.ValidationError(f"Invalid usage key: {data!r}") from err
+        except InvalidKeyError:
+            try:
+                return UsageKey.from_string(urllib.parse.unquote(data))
+            except InvalidKeyError as err:
+                raise serializers.ValidationError(f"Invalid usage key: {data!r}") from err
 
 
 class LtiAgsLineItemSerializer(serializers.ModelSerializer):
@@ -61,11 +64,16 @@ class LtiAgsLineItemSerializer(serializers.ModelSerializer):
     id = serializers.SerializerMethodField()
 
     # Mapping from snake_case to camelCase
-    resourceId = serializers.CharField(source='resource_id')
+    resourceId = serializers.CharField(source='resource_id', required=False)
     scoreMaximum = serializers.IntegerField(source='score_maximum')
-    resourceLinkId = UsageKeyField(required=False, source='resource_link_id')
+    resourceLinkId = EncodedUsageKeyField(required=False, source='resource_link_id')
     startDateTime = serializers.DateTimeField(required=False, source='start_date_time')
     endDateTime = serializers.DateTimeField(required=False, source='end_date_time')
+
+    def validate(self, attrs):
+        if attrs.get('resource_id') is None and attrs.get('resource_link_id') is None:
+            raise serializers.ValidationError("Must provide at least one of resource_id or resource_link_id")
+        return attrs
 
     def get_id(self, obj):
         request = self.context.get('request')
@@ -380,7 +388,7 @@ class LtiContextSerializer(serializers.Serializer):
     """
     Serializer for a LTI Context
     """
-    id = UsageKeyField()
+    id = EncodedUsageKeyField()
 
 
 class LtiNrpsContextMemberBasicSerializer(serializers.Serializer):

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -129,7 +129,7 @@ class LtiAgsScoreSerializer(serializers.ModelSerializer):
     timestamp = serializers.DateTimeField(input_formats=[ISO_8601], format=ISO_8601, default_timezone=timezone.utc)
     scoreGiven = serializers.FloatField(source='score_given', required=False, allow_null=True, default=None)
     scoreMaximum = serializers.FloatField(source='score_maximum', required=False, allow_null=True, default=None)
-    comment = serializers.CharField(required=False, allow_null=True)
+    comment = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     activityProgress = serializers.CharField(source='activity_progress')
     gradingProgress = serializers.CharField(source='grading_progress')
     userId = serializers.CharField(source='user_id')
@@ -197,14 +197,19 @@ class LtiAgsResultSerializer(serializers.ModelSerializer):
     comment = serializers.CharField()
 
     def get_id(self, obj):
+        """
+        Return result URL for score. Include user_id when score scoped to learner.
+        """
         request = self.context.get('request')
+        kwargs = {
+            'lti_config_id': obj.line_item.lti_configuration.id,
+            'pk': obj.line_item.pk,
+        }
+        if obj.user_id:
+            kwargs['user_id'] = obj.user_id
         return reverse(
             'lti_consumer:lti-ags-view-results',
-            kwargs={
-                'lti_config_id': obj.line_item.lti_configuration.id,
-                'pk': obj.line_item.pk,
-                'user_id': obj.user_id,
-            },
+            kwargs=kwargs,
             request=request,
         )
 

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -149,10 +149,14 @@ class LtiAgsScoreSerializer(serializers.ModelSerializer):
 
     def validate_scoreMaximum(self, value):
         """
-        Ensure that scoreMaximum is set when scoreGiven is provided and not None
+        Ensure that scoreMaximum is set to a usable, positive value when scoreGiven is provided.
         """
-        if not value and self.initial_data.get('scoreGiven', None) is not None:
+        if self.initial_data.get('scoreGiven', None) is None:
+            return value
+        if value is None:
             raise serializers.ValidationError('scoreMaximum is a required field when providing a scoreGiven value.')
+        if value <= 0:
+            raise serializers.ValidationError('scoreMaximum must be a positive number when scoreGiven is provided.')
         return value
 
     class Meta:

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -28,7 +28,8 @@ from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredCl
 ISS = "http://test-platform.example/"
 OIDC_URL = "http://test-platform/oidc"
 LAUNCH_URL = "http://test-platform/launch"
-REDIRECT_URIS = [LAUNCH_URL]
+DEEP_LINK_LAUNCH_URL = "http://test-platform/deep_link_launch"
+REDIRECT_URIS = [LAUNCH_URL, DEEP_LINK_LAUNCH_URL]
 CLIENT_ID = "1"
 DEPLOYMENT_ID = "1"
 NONCE = "1234"
@@ -739,14 +740,14 @@ class TestLtiAdvantageConsumer(TestCase):
         """
         Set's up deep linking class in LTI consumer.
         """
-        self.lti_consumer.enable_deep_linking("launch-url", "return-url")
+        self.lti_consumer.enable_deep_linking(DEEP_LINK_LAUNCH_URL, "return-url")
 
         lti_message_hint = self._setup_lti_message_hint()
 
         # Set LTI Consumer parameters
         self.preflight_response = {
             "client_id": CLIENT_ID,
-            "redirect_uri": LAUNCH_URL,
+            "redirect_uri": DEEP_LINK_LAUNCH_URL,
             "nonce": NONCE,
             "state": STATE,
             "lti_message_hint": lti_message_hint,
@@ -817,6 +818,40 @@ class TestLtiAdvantageConsumer(TestCase):
         self.assertEqual(
             decoded_token['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']['deep_link_return_url'],
             "return-url"
+        )
+
+    def test_deep_linking_preflight_uses_deep_link_launch_url(self):
+        """
+        Ensure deep linking launches send the deep linking launch URL as target_link_uri during login initiation.
+        """
+        self.lti_consumer.enable_deep_linking(DEEP_LINK_LAUNCH_URL, "return-url")
+        launch_data = Lti1p3LaunchData(
+            user_id="1",
+            user_role="student",
+            config_id="1",
+            resource_link_id="resource_link_id",
+            message_type="LtiDeepLinkingRequest",
+        )
+
+        preflight_request_data = self.lti_consumer.prepare_preflight_url(launch_data)
+        parameters = parse_qs(urlparse(preflight_request_data).query)
+
+        self.assertEqual(parameters['target_link_uri'][0], DEEP_LINK_LAUNCH_URL)
+
+    def test_deep_linking_launch_request_sets_target_link_uri(self):
+        """
+        Ensure the ID token for deep linking launches uses the deep linking launch URL as target_link_uri.
+        """
+        self._setup_deep_linking()
+
+        token = self.lti_consumer.generate_launch_request(
+            self.preflight_response,
+        )['id_token']
+
+        decoded_token = self.lti_consumer.key_handler.validate_and_decode(token)
+        self.assertEqual(
+            decoded_token['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
+            DEEP_LINK_LAUNCH_URL,
         )
 
     def test_deep_linking_token_decode_no_dl(self):

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -2,27 +2,36 @@
 Unit tests for LTI 1.3 consumer implementation
 """
 
+import uuid
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
-import uuid
 
 import ddt
 import jwt
 from Cryptodome.PublicKey import RSA
 from django.conf import settings
 from django.test.testcases import TestCase
-from edx_django_utils.cache import get_cache_key, TieredCache
+from edx_django_utils.cache import TieredCache, get_cache_key
 from jwt.api_jwk import PyJWKSet
 
 from lti_consumer.data import Lti1p3LaunchData
 from lti_consumer.lti_1p3 import exceptions
 from lti_consumer.lti_1p3.ags import LtiAgs
-from lti_consumer.lti_1p3.deep_linking import LtiDeepLinking
-from lti_consumer.lti_1p3.nprs import LtiNrps
-from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_TYPE, LTI_PROCTORING_DATA_KEYS
+from lti_consumer.lti_1p3.constants import (
+    LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
+    LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    LTI_1P3_CONTEXT_ROLE_LEARNER,
+    LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+    LTI_1P3_CONTEXT_TYPE,
+    LTI_1P3_INSTITUTION_ROLE_ADMINISTRATOR,
+    LTI_1P3_ROLE_BASE,
+    LTI_1P3_SYSTEM_ROLE_ADMINISTRATOR,
+    LTI_PROCTORING_DATA_KEYS,
+)
 from lti_consumer.lti_1p3.consumer import LtiAdvantageConsumer, LtiConsumer1p3, LtiProctoringConsumer
+from lti_consumer.lti_1p3.deep_linking import LtiDeepLinking
 from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredClaim
-
+from lti_consumer.lti_1p3.nprs import LtiNrps
 
 # Variables required for testing and verification
 ISS = "http://test-platform.example/"
@@ -154,17 +163,31 @@ class TestLti1p3Consumer(TestCase):
             return self.lti_consumer._validate_preflight_response(preflight_response)  # pylint: disable=protected-access
 
     @ddt.data(
+        ('student', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
         (
-            'student',
-            ['http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student']
+            'global_staff',
+            LTI_1P3_SYSTEM_ROLE_ADMINISTRATOR +
+            LTI_1P3_INSTITUTION_ROLE_ADMINISTRATOR +
+            LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
         ),
-        (
-            'staff',
-            [
-                'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator',
-                'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
-            ]
-        )
+        ('staff', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_INSTRUCTOR),
+        ('instructor', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR),
+        ('guest', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('limited_staff', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_INSTRUCTOR),
+        ('finance_admin', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('sales_admin', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('beta_testers', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('library_user', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('ccx_coach', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('data_researcher', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('org_course_creator_group', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('course_creator_group', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('support', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('Administrator', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('Moderator', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
+        ('Group Moderator', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT),
+        ('Community TA', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT),
+        ('Student', LTI_1P3_ROLE_BASE + LTI_1P3_CONTEXT_ROLE_LEARNER),
     )
     @ddt.unpack
     def test_get_user_roles(self, role, expected_output):
@@ -238,7 +261,9 @@ class TestLti1p3Consumer(TestCase):
             {
                 "sub": "1",
                 "https://purl.imsglobal.org/spec/lti/claim/roles": [
-                    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student"
+                    "http://purl.imsglobal.org/vocab/lis/v2/system/person#None",
+                    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#None",
+                    "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
                 ]
             }
         ),
@@ -267,10 +292,14 @@ class TestLti1p3Consumer(TestCase):
         Check if setting user data works
         """
         self.lti_consumer.set_user_data(**data)
-        self.assertEqual(
-            self.lti_consumer.lti_claim_user_data,
-            expected_output
-        )
+
+        actual_output = self.lti_consumer.lti_claim_user_data.copy()
+        expected_output = expected_output.copy()
+        actual_roles = actual_output.pop("https://purl.imsglobal.org/spec/lti/claim/roles")
+        expected_roles = expected_output.pop("https://purl.imsglobal.org/spec/lti/claim/roles")
+
+        self.assertEqual(actual_output, expected_output)
+        self.assertCountEqual(actual_roles, expected_roles)
 
     def test_check_no_user_data_error(self):
         """

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1096,7 +1096,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             close_date = due_date
         return close_date is not None and timezone.now() > close_date
 
-    def _get_lti_consumer(self):
+    def get_lti_consumer(self):
         """
         Returns a preconfigured LTI consumer depending on the value.
 
@@ -1269,7 +1269,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Returns:
             webob.response: HTML LTI launch form
         """
-        lti_consumer = self._get_lti_consumer()
+        lti_consumer = self.get_lti_consumer()
 
         # Occassionally, users try to do an LTI launch while they are unauthenticated. It is not known why this occurs.
         # Sometimes, it is due to a web crawlers; other times, it is due to actual users of the platform. Regardless,
@@ -1372,7 +1372,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Asserting that the consumer can be created. This makes sure that the LtiConfiguration
         # object exists before calling the Django View
-        assert self._get_lti_consumer()
+        assert self.get_lti_consumer()
         # Runtime import because this can only be run in the LMS/Studio Django
         # environments. Importing the views on the top level will cause RuntimeErorr
         from lti_consumer.plugin.views import access_token_endpoint  # pylint: disable=import-outside-toplevel
@@ -1428,12 +1428,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Returns:
             webob.response:  response to this request.  See above for details.
         """
-        lti_consumer = self._get_lti_consumer()
+        lti_consumer = self.get_lti_consumer()
         lti_consumer.set_outcome_service_url(self.outcome_service_url)
 
         if settings.DEBUG:
-            lti_provider_key, lti_provider_secret = self.lti_provider_key_secret
-            log_authorization_header(request, lti_provider_key, lti_provider_secret)
+            log_authorization_header(request, lti_consumer.oauth_key, lti_consumer.oauth_secret)
 
         if not self.accept_grades_past_due and self.is_past_due:
             return Response(status=404)  # have to do 404 due to spec, but 400 is better, with error msg in body
@@ -1588,11 +1587,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         self.module_score = scaled_score
         self.score_comment = comment
 
-    def _get_lti_launch_url(self, consumer):
+    def _get_lti_launch_url(self, consumer) -> str:
         """
         Return the LTI launch URL.
         """
-        launch_url = self.launch_url
+        launch_url = str(self.launch_url)
 
         # The lti_launch_url property only exists on the LtiConsumer1p1. The LtiConsumer1p3 does not have an
         # attribute with this name, so ensure that we're accessing it on the appropriate consumer class.
@@ -1745,7 +1744,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Don't pull from the Django database unless the config_type is one that stores the LTI configuration in the
         # database.
         if self.config_type in ("database", "external"):
-            lti_consumer = self._get_lti_consumer()
+            lti_consumer = self.get_lti_consumer()
 
         launch_url = self._get_lti_launch_url(lti_consumer)
         lti_block_launch_handler = self._get_lti_block_launch_handler()

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1575,7 +1575,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         self.runtime.service(self, 'rebind_user').rebind_noauth_module_to_user(self, user)
         args = []
-        if self.module_score:
+        # `is not None`, not a truthiness check: a `module_score` of 0 is falsy but a legitimate,
+        # already-graded score -- the same falsy-zero pattern fixed for LTI 1.3 AGS elsewhere.
+        if self.module_score is not None:
             args.extend([self.module_score, self.score_comment])
         return lti_consumer.get_result(*args)
 

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -926,6 +926,32 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             raise LtiError(self.ugettext("Could not get user id for current request"))
         return str(user_id)
 
+    def _get_lti_1p3_user_role(self):
+        """
+        Return effective LTI 1.3 user role, including supported forum roles.
+        """
+        role = self.role
+
+        # Map Global staff to instance-admin LTI role set.
+        if self.user_is_staff:
+            return 'global_staff'
+
+        # Keep privileged course roles unchanged.
+        # `staff`, `instructor`, and `limited_staff` already map to stronger LTI roles
+        # than forum roles like `Community TA` or `Group Moderator`, so forum role
+        # should only override learner-like base roles.
+        if role in {'staff', 'instructor', 'limited_staff'}:
+            return role
+
+        forum_role = compat.get_user_course_forum_role(
+            self.lms_user_id,
+            self.scope_ids.usage_id.context_key,
+        )
+        if forum_role in {'Community TA', 'Group Moderator'}:
+            return forum_role
+
+        return role
+
     def get_lti_1p1_user_id(self):
         """
         Returns the user ID to send to an LTI tool during an LTI 1.1/2.0 launch. If the
@@ -1665,7 +1691,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         launch_data = Lti1p3LaunchData(
             user_id=self.lms_user_id,
-            user_role=self.role,
+            user_role=self._get_lti_1p3_user_role(),
             config_id=config_id,
             resource_link_id=str(location),
             external_user_id=self.external_user_id,

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -74,6 +74,7 @@ except ModuleNotFoundError:  # For backward compatibility with releases older th
 
 from .data import Lti1p3LaunchData
 from .exceptions import LtiError
+from .filters import get_external_config_from_filter
 from .lti_1p1.consumer import LtiConsumer1p1, parse_result_json, LTI_PARAMETERS
 from .lti_1p1.oauth import log_authorization_header
 from .outcomes import OutcomeService
@@ -702,7 +703,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # a new LTI ID before they've added it to advanced settings, but we do want to warn them about it.
         # If we put this check in validate_field_data(), the settings editor wouldn't let them save changes.
         course = self.course
-        if course and self.lti_version == "lti_1p1" and self.lti_id:
+        if course and self.config_type == "new" and self.lti_version == "lti_1p1" and self.lti_id:
             lti_passport_ids = [lti_passport.split(':')[0].strip() for lti_passport in course.lti_passports]
             if self.lti_id.strip() not in lti_passport_ids:
                 validation.add(ValidationMessage(ValidationMessage.WARNING, str(
@@ -1145,6 +1146,68 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         return get_lti_consumer(config_id_for_block(self))
 
+    def get_resolved_lti_version(self):
+        """
+        Return the effective LTI version for this block.
+
+        When `config_type` is `"external"`, the version is determined
+        by the external re-usable config's `version` key, not by the
+        block's own `lti_version` field.  Falls back to `self.lti_version`
+        for non-external configs or when external config has no version.
+
+        If the external config lookup raises (e.g. filter service
+        unavailable), the exception is logged and the block's own
+        `lti_version` is returned as a safe fallback.
+        """
+        if self.config_type != "external":
+            return self.lti_version
+
+        try:
+            config = get_external_config_from_filter(
+                {"course_key": self.scope_ids.usage_id.context_key},
+                self.external_config,
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to resolve external config version for config_id=%s; "
+                "falling back to block-level lti_version=%s",
+                self.external_config,
+                self.lti_version,
+            )
+            return self.lti_version
+
+        return config.get("version") or self.lti_version
+
+    @XBlock.json_handler
+    def resolve_external_config_version(self, data, suffix=''):  # pylint: disable=unused-argument
+        """
+        Handler for Studio to resolve the LTI version for a given
+        external config ID.  Returns only the version — no secrets
+        from the external configuration are exposed.
+
+        If the filter lookup raises (e.g. service unavailable), the
+        exception is logged and a safe fallback response is returned
+        so the Studio UI degrades gracefully.
+        """
+        config_id = data.get('config_id', '')
+        if not config_id:
+            return {'found': False, 'version': None}
+
+        try:
+            config = get_external_config_from_filter(
+                {"course_key": self.scope_ids.usage_id.context_key},
+                config_id,
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to resolve external config version for config_id=%s",
+                config_id,
+            )
+            return {'found': False, 'version': None}
+
+        version = config.get("version") if config else None
+        return {'found': version is not None, 'version': version}
+
     def extract_real_user_data(self):
         """
         Extract and return real user data from the runtime
@@ -1228,7 +1291,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         If using LTI 1.3 it displays a fragment with parameters that
         need to be set on the LTI Tool to make the integration work.
         """
-        if self.lti_version == "lti_1p1":
+        if self.get_resolved_lti_version() == "lti_1p1":
             return self.student_view(context)
 
         # Render template
@@ -1266,7 +1329,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Prepend the author view for LTI1.3 when rendering student view to staff users in Studio.
         # This is needed so course staff can see the author view parameters when configuring within Libraries v2
-        if settings.SERVICE_VARIANT != 'lms' and self.lti_version == "lti_1p3" and self.user_is_staff:
+        if settings.SERVICE_VARIANT != 'lms' and self.get_resolved_lti_version() == "lti_1p3" and self.user_is_staff:
             self._add_author_view(context, loader, fragment)
 
         fragment.add_content(loader.render_mako_template('/templates/html/student.html', context))
@@ -1393,7 +1456,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             Sucess: https://tools.ietf.org/html/rfc6749#section-4.4.3
             Failure: https://tools.ietf.org/html/rfc6749#section-5.2
         """
-        if self.lti_version != "lti_1p3":
+        if self.get_resolved_lti_version() != "lti_1p3":
             return Response(status=404)
 
         # Asserting that the consumer can be created. This makes sure that the LtiConfiguration
@@ -1621,7 +1684,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # The lti_launch_url property only exists on the LtiConsumer1p1. The LtiConsumer1p3 does not have an
         # attribute with this name, so ensure that we're accessing it on the appropriate consumer class.
-        if consumer and self.config_type in ("database", "external") and self.lti_version == "lti_1p1":
+        if consumer and self.config_type in ("database", "external") and self.get_resolved_lti_version() == "lti_1p1":
             launch_url = consumer.lti_launch_url
 
         return launch_url
@@ -1723,7 +1786,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Return the LTI block launch handler.
         """
-        if self.lti_version == 'lti_1p1':
+        if self.get_resolved_lti_version() == 'lti_1p1':
             lti_block_launch_handler = self.runtime.handler_url(self, 'lti_launch_handler').rstrip('/?')
         else:
             launch_data = self.get_lti_1p3_launch_data()
@@ -1744,7 +1807,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         lti_1p3_launch_url = self.lti_1p3_launch_url.strip()
 
         # Get LTI launch URL from consumer if using database or external configuration type.
-        if consumer and self.lti_version == 'lti_1p3' and self.config_type in ('database', 'external'):
+        if consumer and self.get_resolved_lti_version() == 'lti_1p3' and self.config_type in ('database', 'external'):
             lti_1p3_launch_url = consumer.launch_url
 
         return lti_1p3_launch_url
@@ -1803,7 +1866,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'modal_horizontal_offset': self._get_modal_position_offset(self.modal_width),
             'modal_width': self.modal_width,
             'accept_grades_past_due': self.accept_grades_past_due,
-            'lti_version': self.lti_version,
+            'lti_version': self.get_resolved_lti_version(),
         }
 
     def _get_modal_position_offset(self, viewport_percentage):

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -599,9 +599,7 @@ class LtiConfiguration(models.Model):
                 lti_oidc_url=self.external_config.get('lti_1p3_oidc_url'),
                 lti_launch_url=lti_launch_url,
                 client_id=self.external_config.get('lti_1p3_client_id'),
-                # Deployment ID hardcoded to 1 since
-                # we're not using multi-tenancy.
-                deployment_id='1',
+                deployment_id=self.external_config.get('lti_1p3_deployment_id', "1"),
                 rsa_key=self.external_config.get('lti_1p3_private_key'),
                 rsa_key_id=self.external_config.get('lti_1p3_private_key_id'),
                 # Registered redirect uris

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -619,12 +619,31 @@ class LtiConfiguration(models.Model):
 
         return consumer
 
+    def get_effective_version(self):
+        """
+        Return the effective LTI version for this configuration.
+
+        When ``config_store == CONFIG_EXTERNAL``, checks the external config
+        for a ``version`` key and returns it.  Falls back to ``self.version``.
+        """
+        if self.config_store == self.CONFIG_EXTERNAL:
+            ext_version = self.external_config.get('version')
+            if ext_version is not None:
+                return ext_version
+        return self.version
+
     @function_trace('lti_consumer.models.LtiConfiguration.get_lti_consumer')
     def get_lti_consumer(self):
         """
         Returns an instanced class of LTI 1.1 or 1.3 consumer.
+
+        When using external config, the version from the external config
+        takes priority over the locally stored version to avoid version
+        mismatch crashes.
         """
-        if self.version == self.LTI_1P3:
+        effective_version = self.get_effective_version()
+
+        if effective_version == self.LTI_1P3:
             return self._get_lti_1p3_consumer()
 
         return self._get_lti_1p1_consumer()

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -821,9 +821,15 @@ class LtiAgsScore(models.Model):
     def clean(self):
         super().clean()
 
-        # 'scoreMaximum' represents the denominator and MUST be present when 'scoreGiven' is present.
-        # A 'scoreGiven' of 0 is a valid score, so check for presence rather than truthiness.
-        if self.score_given is not None and self.score_maximum is None:
+        # 'scoreMaximum' represents the denominator and MUST be a usable, positive value when
+        # 'scoreGiven' is present -- `score_maximum <= 0` can't be published either (see
+        # `publish_grade_on_score_update`), and letting it through here made it possible for
+        # `LtiAgsResultSerializer.get_resultMaximum` to report a fabricated "successful" result
+        # for a score that was never actually published to the gradebook.
+        # Note: this must be an `is not None` check on `score_given`, not a truthiness check,
+        # since a `scoreGiven` of 0 is falsy but a legitimate value that still requires a
+        # `scoreMaximum`.
+        if self.score_given is not None and not self.score_maximum:
             raise ValidationError({'score_maximum': 'cannot be unset when score_given is set'})
 
     def save(self, *args, **kwargs):

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -821,8 +821,9 @@ class LtiAgsScore(models.Model):
     def clean(self):
         super().clean()
 
-        # 'scoreMaximum' represents the denominator and MUST be present when 'scoreGiven' is present
-        if self.score_given and self.score_maximum is None:
+        # 'scoreMaximum' represents the denominator and MUST be present when 'scoreGiven' is present.
+        # A 'scoreGiven' of 0 is a valid score, so check for presence rather than truthiness.
+        if self.score_given is not None and self.score_maximum is None:
             raise ValidationError({'score_maximum': 'cannot be unset when score_given is set'})
 
     def save(self, *args, **kwargs):

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -6,10 +6,12 @@ https://www.imsglobal.org/specs/ltiomv1p0
 """
 
 import logging
-from xml.sax.saxutils import escape
 from urllib.parse import unquote
+from xml.sax.saxutils import escape
 
+from django.conf import settings
 from lxml import etree
+
 try:
     from xblock.utils.resources import ResourceLoader
 except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
@@ -176,7 +178,13 @@ class OutcomeService:
             return response_xml_template.format(**failure_values)
 
         # Verify OAuth signing.
-        __, secret = self.xblock.lti_provider_key_secret
+        secret = self.xblock.get_lti_consumer().oauth_secret
+        if settings.DEBUG:
+            log.debug(
+                "[LTI]: verifying OAuth body signature for outcomes. service_url=%s request.url=%s",
+                self.xblock.outcome_service_url,
+                request.url,
+            )
         try:
             verify_oauth_body_signature(request, secret, self.xblock.outcome_service_url)
         except (ValueError, LtiError) as ex:

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -329,6 +329,99 @@ def get_event_tracker():  # pragma: nocover
         return None
 
 
+def _select_supported_forum_role(forum_roles):
+    """
+    Return supported forum role with stable precedence.
+    """
+    if 'Group Moderator' in forum_roles:
+        return 'Group Moderator'
+    if 'Community TA' in forum_roles:
+        return 'Community TA'
+    return None
+
+
+def get_forum_role_model():  # pragma: nocover
+    """
+    Return discussion Role model if available.
+    """
+    try:
+        # pylint: disable=import-outside-toplevel
+        from openedx.core.djangoapps.django_comment_common.models import Role
+        return Role
+    except ImportError:
+        return None
+
+
+def get_user_course_forum_role(user_id, course_id):  # pragma: nocover
+    """
+    Return exact forum access role for user in course when it maps to LTI 1.3 forum roles.
+    """
+    target_roles = {'Community TA', 'Group Moderator'}
+
+    try:
+        # pylint: disable=import-outside-toplevel
+        from django.contrib.auth import get_user_model
+        from lms.djangoapps.discussion.django_comment_client.utils import get_user_role_names
+
+        user = get_user_model().objects.get(id=user_id)
+        forum_roles = set(get_user_role_names(user, course_id))
+        return _select_supported_forum_role(forum_roles)
+    except ImportError:
+        role_model = get_forum_role_model()
+        if role_model is None:
+            return None
+
+        user_forum_roles = set(
+            role_model.objects.filter(
+                users__id=user_id,
+                course_id=course_id,
+                name__in=target_roles,
+            ).values_list('name', flat=True)
+        )
+
+        return _select_supported_forum_role(user_forum_roles)
+
+
+def merge_course_forum_roles(course_id, members):  # pragma: nocover
+    """
+    Merge supported forum roles into NRPS member role lists.
+
+    Privileged course roles keep precedence over forum roles to match launch behavior.
+    """
+    target_roles = {'Community TA', 'Group Moderator'}
+    privileged_roles = {'staff', 'instructor', 'limited_staff'}
+
+    role_model = get_forum_role_model()
+    if role_model is not None:
+        forum_roles_by_user = {}
+        for user_id, role_name in role_model.objects.filter(
+            users__id__in=members.keys(),
+            course_id=course_id,
+            name__in=target_roles,
+        ).values_list('users__id', 'name'):
+            forum_roles_by_user.setdefault(user_id, set()).add(role_name)
+
+        for user_id, member in members.items():
+            if privileged_roles.intersection(member.get('roles', [])):
+                continue
+
+            forum_role = _select_supported_forum_role(forum_roles_by_user.get(user_id, set()))
+            if forum_role and forum_role not in member['roles']:
+                member['roles'].append(forum_role)
+
+        return members
+
+    for user_id, member in members.items():
+        if privileged_roles.intersection(member.get('roles', [])):
+            continue
+
+        forum_role = get_user_course_forum_role(user_id, course_id)
+        if forum_role and forum_role not in member['roles']:
+            member['roles'].append(forum_role)
+
+    return members
+
+
 def nrps_pii_disallowed():
     """
     Check if platform disallows sharing pii over NRPS

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -835,6 +835,7 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
 
         try:
             data = compat.get_course_members(course_key)
+            compat.merge_course_forum_roles(course_key, data)
             self.attach_external_user_ids(data)
 
             # build correct format for the serializer

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -52,6 +52,73 @@ from lti_consumer.track import track_event
 from lti_consumer.utils import _, get_data_from_cache, get_lti_1p3_context_types_claim, get_lti_api_base
 from lti_consumer.filters import get_external_config_from_filter
 
+
+def _build_url_with_query(request, query_params):
+    """
+    Build an absolute URL from the request path, merging current query parameters
+    and overriding/removing keys as specified.
+
+    Args:
+        request: DRF request object.
+        query_params: dict of query parameter key/value pairs to set.
+            Keys set to ``None`` are removed from the result.
+
+    Returns:
+        str: Absolute URL with the resulting query parameters.
+    """
+    base_url = request.build_absolute_uri(request.path)
+    # Start from current query params and apply overrides/removals.
+    # Use .dict() (not dict()) to get single values from MultiValueDict.
+    merged = request.query_params.dict()
+    for key, value in query_params.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    if merged:
+        return f"{base_url}?{urllib.parse.urlencode(merged)}"
+    return base_url
+
+
+def _format_link_header(url, rel):
+    """
+    Format an RFC 8288 Link header value.
+
+    Args:
+        url: The target URL.
+        rel: The link relation type (e.g. 'next').
+
+    Returns:
+        str: Formatted Link header value.
+    """
+    return f'<{url}>; rel="{rel}"'
+
+
+def _parse_positive_int(value, default=None):
+    """
+    Parse *value* (a string or ``None``) as a positive integer.
+
+    Returns *default* if *value* is ``None``, not an integer, or
+    non-positive.
+
+    Args:
+        value: Raw string or ``None``.
+        default: Fallback value (default ``None``).
+
+    Returns:
+        int or *default*.
+    """
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (ValueError, TypeError):
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
+
 log = logging.getLogger(__name__)
 
 
@@ -826,6 +893,18 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Overrides default list method of ModelViewSet. Calls LMS `get_course_members`
         API and returns result.
+
+        Supports manual pagination via ``limit`` and ``page`` query parameters
+        (per NRPS 2.0 §2.4.2):
+
+        * limit (positive integer): Maximum members per page.  When absent,
+          all members are returned and no pagination Link header is emitted.
+        * page (positive integer, default 1): 1-indexed page number.
+          Only consulted when ``limit`` is present and valid.
+
+        When ``limit`` is present and more members remain after the current
+        page, a ``Link`` header with ``rel="next"`` is included whose URL
+        carries the same ``limit`` and an incremented ``page``.
         """
 
         # get course key
@@ -836,18 +915,48 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
             compat.merge_course_forum_roles(course_key, data)
             self.attach_external_user_ids(data)
 
+            # The LMS combines unordered enrollment and role-only querysets, so
+            # dict insertion order can change between paginated requests.
+            members = sorted(data.values(), key=lambda m: m['id'])
+            total_count = len(members)
+
+            limit_param = self.request.query_params.get('limit')
+            has_next = False
+            page = 1
+
+            if limit_param is not None:
+                limit = _parse_positive_int(limit_param, default=None)
+                if limit is not None:
+                    page = _parse_positive_int(
+                        self.request.query_params.get('page'),
+                        default=1,
+                    )
+                    start = (page - 1) * limit
+                    end = start + limit
+                    members = members[start:end]
+                    has_next = end < total_count
+
             # build correct format for the serializer
             result = {
                 'id': self.request.build_absolute_uri(),
                 'context': {
                     'id': course_key
                 },
-                'members': data.values(),
+                'members': members,
             }
 
             # Serialize and return data NRPS reponse.
             serializer = self.get_serializer_class()(result)
-            return Response(serializer.data)
+            response = Response(serializer.data)
+
+            if has_next:
+                next_url = _build_url_with_query(self.request, {
+                    'limit': limit,
+                    'page': page + 1,
+                })
+                response['Link'] = _format_link_header(next_url, 'next')
+
+            return response
 
         except LtiError as ex:
             log.warning("LTI NRPS Error: %s", ex)

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -703,7 +703,7 @@ class LtiAgsLineItemViewset(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=['GET'],
-        url_path='results/(?P<user_id>[^/.]+)?',
+        url_path=r'results(?:/(?P<user_id>[^/.]+))?/?',
         renderer_classes=[LineItemResultsRenderer],
         content_negotiation_class=IgnoreContentNegotiation,
     )

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -297,7 +297,7 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
         if launch_data.custom_parameters:
             lti_consumer.set_custom_parameters(launch_data.custom_parameters)
 
-        # Modify LTI Launch URL depending on launch type.
+        # Modify LTI launch parameters depending on launch type.
         # Deep Linking Launch - Configuration flow launched by
         # course creators to set up content.
         deep_linking_content_item_id = launch_data.deep_linking_content_item_id
@@ -307,8 +307,6 @@ def launch_gate_endpoint(request, suffix=None):  # pylint: disable=unused-argume
             # If not, raise exception and display error page
             if user_role not in ['instructor', 'staff']:
                 raise AssertionError('Deep Linking can only be performed by instructors and staff.')
-            # Set deep linking launch
-            context.update({'launch_url': lti_consumer.dl.deep_linking_launch_url})
 
         # Deep Linking ltiResourceLink content presentation
         # When content type is `ltiResourceLink`, the tool will be launched with

--- a/lti_consumer/signals/signals.py
+++ b/lti_consumer/signals/signals.py
@@ -44,9 +44,11 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
     # 1. The grade being submitted in the final one - `FullyGraded`
     # 2. This LineItem is linked to a LMS grade - the `LtiResouceLinkId` field is set
     # 3. There's a valid grade in this score - `scoreGiven` is set
+    #    Note: a `scoreGiven` of 0 is a valid grade, so this must be an explicit
+    #    `is not None` check rather than a truthiness one.
     if instance.grading_progress == LtiAgsScore.FULLY_GRADED \
             and line_item.resource_link_id \
-            and instance.score_given:
+            and instance.score_given is not None:
         try:
             # Load block using LMS APIs and check if the block is graded and still accept grades.
             block = compat.load_block_as_user(line_item.resource_link_id)

--- a/lti_consumer/signals/signals.py
+++ b/lti_consumer/signals/signals.py
@@ -40,19 +40,54 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
         )
         return
 
-    # Before starting to publish grades to the LMS, check that:
-    # 1. The grade being submitted in the final one - `FullyGraded`
-    # 2. This LineItem is linked to a LMS grade - the `LtiResouceLinkId` field is set
-    # 3. There's a valid grade in this score - `scoreGiven` is set
-    #    Note: a `scoreGiven` of 0 is a valid grade, so this must be an explicit
-    #    `is not None` check rather than a truthiness one.
-    if instance.grading_progress == LtiAgsScore.FULLY_GRADED \
-            and line_item.resource_link_id \
-            and instance.score_given is not None:
-        try:
-            # Load block using LMS APIs and check if the block is graded and still accept grades.
-            block = compat.load_block_as_user(line_item.resource_link_id)
-            if block.has_score and (not block.is_past_due() or block.accept_grades_past_due):
+    # The grade being submitted must be the final one - `FullyGraded`. This is routine, expected
+    # tool behavior to not be the case yet (interim `Pending`/`InProgress` saves are far more
+    # common than the final one), so it's silently skipped here, not logged, to avoid flooding
+    # the logs.
+    if instance.grading_progress != LtiAgsScore.FULLY_GRADED:
+        return
+
+    # From here on the score is final, so failing to publish it is the actionable case worth
+    # logging below. Before publishing to the LMS, check that:
+    # 1. This LineItem is linked to a LMS grade - the `LtiResouceLinkId` field is set
+    # 2. There's a grade present in this score - `scoreGiven` is present
+    # 3. `scoreMaximum` is a usable, positive denominator for the normalized score below
+    # Note: (2) and (3) must be `is not None`/range checks, not truthiness checks, since a
+    # `scoreGiven` or `scoreMaximum` of 0 is falsy but a legitimate value for the former.
+    can_publish = (
+        bool(line_item.resource_link_id) and
+        instance.score_given is not None and
+        instance.score_maximum is not None and
+        instance.score_maximum > 0
+    )
+    if not can_publish:
+        log.info(
+            "LTI AGS grade publish skipped: score=%r grading_progress=%s resource_link_id=%s "
+            "score_given=%s score_maximum=%s.",
+            instance,
+            instance.grading_progress,
+            line_item.resource_link_id,
+            instance.score_given,
+            instance.score_maximum,
+        )
+        return
+
+    try:
+        # Load block using LMS APIs and check if the block is graded and still accept grades.
+        block = compat.load_block_as_user(line_item.resource_link_id)
+        if not block.has_score:
+            log.info(
+                "LTI AGS grade publish skipped: score=%r resource_link_id=%s has_score=%s.",
+                instance,
+                line_item.resource_link_id,
+                block.has_score,
+            )
+        else:
+            # Computed once and reused below: previously `is_past_due()`/`accept_grades_past_due`
+            # were never evaluated at all when `has_score` was False (short-circuited by `and`),
+            # so neither is touched here unless `has_score` is True.
+            is_past_due = block.is_past_due()
+            if not is_past_due or block.accept_grades_past_due:
                 # Map external ID to platform user
                 user = compat.get_user_from_external_user_id(instance.user_id)
 
@@ -71,17 +106,27 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
                     score,
                 )
                 block.set_user_module_score(user, score, block.max_score(), instance.comment)
+            else:
+                log.info(
+                    "LTI AGS grade publish skipped: score=%r resource_link_id=%s has_score=%s "
+                    "is_past_due=%s accept_grades_past_due=%s.",
+                    instance,
+                    line_item.resource_link_id,
+                    block.has_score,
+                    is_past_due,
+                    block.accept_grades_past_due,
+                )
 
-        # This is a catch all exception to catch and log any issues related to loading the block
-        # from the modulestore and other LMS API calls
-        except Exception as exc:
-            log.exception(
-                "Error while publishing score %r to block %s to LMS: %s",
-                instance,
-                line_item.resource_link_id,
-                exc,
-            )
-            raise exc
+    # This is a catch all exception to catch and log any issues related to loading the block
+    # from the modulestore and other LMS API calls
+    except Exception as exc:
+        log.exception(
+            "Error while publishing score %r to block %s to LMS: %s",
+            instance,
+            line_item.resource_link_id,
+            exc,
+        )
+        raise exc
 
 
 LTI_1P3_PROCTORING_ASSESSMENT_STARTED = Signal()

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -70,9 +70,10 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
     /**
      * Return fields that should be hidden based on the selected config type.
      *
-     *  new - Show all the LTI 1.1/1.3 config fields
-     *  database - Do not show the LTI 1.1/1.3 config fields
-     *  external - Show only the External Config ID field
+     *  new - Show all the LTI 1.1/1.3 config fields. Hide the Reusable Configuration ID field.
+     *  database - Do not show the LTI 1.1/1.3 config fields. Hide the Reusable Configuration ID field.
+     *  external - Show only the Reusable Configuration ID field. Hide LTI version, since it is
+     *             determined by the reusable config itself, not editable on this block.
      */
     function getFieldsToHideForLtiConfigType() {
         const configType = $(element).find('#xb-field-edit-config_type').val();
@@ -92,14 +93,20 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
                     fieldsToHide.splice(index, 1);
                 }
             }
+            // LTI version is determined by the reusable config, not editable on this block.
+            fieldsToHide.push("lti_version");
         } else if (configType === "database") {
             // Hide the LTI 1.1 and LTI 1.3 fields. The XBlock will remain the source of truth for the lti_version,
             // so do not hide it and continue to allow editing it from the XBlock edit menu in Studio.
             databaseConfigHiddenFields.forEach(function (field) {
                 fieldsToHide.push(field);
             })
+            // Reusable Configuration ID is not applicable for database-backed configuration.
+            fieldsToHide.push("external_config");
         } else {
-            // No fields should be hidden based on a config_type of 'new'.
+            // config_type of 'new': show all LTI 1.1/1.3 fields (handled above/below).
+            // Reusable Configuration ID is not applicable when configuring the tool directly on the block.
+            fieldsToHide.push("external_config");
         }
 
         return fieldsToHide;
@@ -127,7 +134,10 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
      * Show or hide fields depending on the selected lti_version, config_type, and lti_1p3_tool_key_mode.
      */
     function toggleLtiFields() {
-        const configFields = lti1P1FieldList.concat(lti1P3FieldList);
+        // lti_version and external_config are toggled based on config_type (see
+        // getFieldsToHideForLtiConfigType), not on the LTI 1.1/1.3 field lists, but they still
+        // need to be reset to visible here so a later config_type change can show them again.
+        const configFields = lti1P1FieldList.concat(lti1P3FieldList).concat(["lti_version", "external_config"]);
         const hiddenFields = new Set();
 
         // Start with the assumption that all configFields should be visible. After that, we whittle down the

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -417,13 +417,18 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
 
-    @ddt.data(True, False)
-    def test_launch_callback_endpoint_deep_linking_database_config(self, dl_enabled):
+    @ddt.data(
+        (True, "LtiDeepLinkingRequest"),
+        (False, "LtiResourceLinkRequest"),
+    )
+    @ddt.unpack
+    def test_launch_callback_endpoint_deep_linking_database_config(self, dl_enabled, message_type):
         """
-        Test that Deep Linking is enabled and that the context is updated appropriately when using the 'database'
-        config_type.
+        Test that the form action for deep linking requests uses the tool-provided
+        redirect_uri, NOT the platform-configured deep_linking_launch_url.
         """
-        url = "http://tool.example/deep_linking_launch"
+        redirect_uri = "http://tool.example/lti-advantage-connect"
+        deep_link_url = "http://tool.example/lti-advantage-select"
         self._setup_deep_linking(user_role='staff')
 
         self.xblock.config_type = 'database'
@@ -433,15 +438,16 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
             version=LtiConfiguration.LTI_1P3,
             config_store=LtiConfiguration.CONFIG_ON_DB,
             lti_advantage_deep_linking_enabled=dl_enabled,
-            lti_advantage_deep_linking_launch_url=url,
+            lti_advantage_deep_linking_launch_url=deep_link_url,
+            lti_1p3_redirect_uris=[redirect_uri],
         )
         if dl_enabled:
-            self.xblock.lti_advantage_deep_linking_launch_url = url
-            self.launch_data.message_type = "LtiDeepLinkingRequest"
+            self.xblock.lti_advantage_deep_linking_launch_url = deep_link_url
+        self.launch_data.message_type = message_type
 
         params = {
             "client_id": self.config.lti_1p3_client_id,
-            "redirect_uri": "http://tool.example/launch",
+            "redirect_uri": redirect_uri,
             "state": "state_test_123",
             "nonce": "nonce",
             "login_hint": self.launch_data.user_id,
@@ -453,12 +459,9 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         self.assertEqual(response.status_code, 200)
         response_body = response.content.decode('utf-8')
 
-        # If Deep Linking is enabled, test that deep linking launch URL is in the rendered template. Otherwise, test
-        # that it is not.
-        if dl_enabled:
-            self.assertIn(url, response_body)
-        else:
-            self.assertNotIn(url, response_body)
+        # Form action must be the tool-provided redirect_uri, not deep_linking_launch_url
+        self.assertIn(f'action="{redirect_uri}"', response_body)
+        self.assertNotIn(f'action="{deep_link_url}"', response_body)
 
     def test_launch_callback_endpoint_deep_linking_by_student(self):
         """

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -3,17 +3,16 @@ Tests for LTI Advantage Assignments and Grades Service views.
 """
 import json
 from datetime import timedelta
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-from Cryptodome.PublicKey import RSA
 import ddt
+from Cryptodome.PublicKey import RSA
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APITransactionTestCase
 
-
 from lti_consumer.lti_xblock import LtiConsumerXBlock
-from lti_consumer.models import LtiConfiguration, LtiAgsLineItem, LtiAgsScore
+from lti_consumer.models import LtiAgsLineItem, LtiAgsScore, LtiConfiguration
 from lti_consumer.tests.test_utils import make_xblock
 
 
@@ -234,6 +233,27 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
                 'startDateTime': None,
                 'endDateTime': None,
             }
+        )
+
+    def test_create_lti_lineitem_validation(self):
+        """
+        Test LTI LineItem Creation Validation.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/lineitem')
+
+        response = self.client.post(
+            self.lineitem_endpoint,
+            data=json.dumps({
+                'scoreMaximum': 100,
+                'label': 'test',
+                'tag': 'score',
+            }),
+            content_type="application/vnd.ims.lis.v2.lineitem+json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            str(response.data['non_field_errors'][0]),
+            'Must provide at least one of resource_id or resource_link_id'
         )
 
     def test_create_lineitem(self):

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -177,10 +177,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
             response.data,
             [
                 {
-                    'id': 'http://testserver/lti_consumer/v1/lti/{}/lti-ags/{}'.format(
-                        self.lti_config.id,
-                        line_item.id
-                    ),
+                    'id': f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags/{line_item.id}',
                     'resourceId': 'test',
                     'scoreMaximum': 100,
                     'label': 'test label',
@@ -221,10 +218,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(
             response.data,
             {
-                'id': 'http://testserver/lti_consumer/v1/lti/{}/lti-ags/{}'.format(
-                    self.lti_config.id,
-                    line_item.id
-                ),
+                'id': f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags/{line_item.id}',
                 'resourceId': 'test',
                 'scoreMaximum': 100,
                 'label': 'test label',
@@ -400,6 +394,43 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(score.activity_progress, LtiAgsScore.COMPLETED)
         self.assertEqual(score.grading_progress, LtiAgsScore.FULLY_GRADED)
         self.assertEqual(score.user_id, self.primary_user_id)
+
+    @ddt.data(None, "")
+    def test_create_score_without_comment(self, comment):
+        """
+        Test the LTI AGS LineItem Score Creation when comment is omitted or blank.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/score')
+
+        data = {
+            "timestamp": self.early_timestamp,
+            "scoreGiven": 83,
+            "scoreMaximum": 100,
+            "activityProgress": LtiAgsScore.COMPLETED,
+            "gradingProgress": LtiAgsScore.FULLY_GRADED,
+            "userId": self.primary_user_id,
+        }
+        if comment is not None:
+            data["comment"] = comment
+
+        response = self.client.post(
+            self.scores_endpoint,
+            data=json.dumps(data),
+            content_type="application/vnd.ims.lis.v1.score+json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(LtiAgsScore.objects.filter(
+            line_item=self.line_item,
+            user_id=self.primary_user_id
+        ).count(), 1)
+
+        score = LtiAgsScore.objects.get(line_item=self.line_item, user_id=self.primary_user_id)
+        if comment is None:
+            self.assertIsNone(score.comment)
+        else:
+            self.assertEqual(score.comment, comment)
+        score.delete()
 
     def _post_lti_score(self, override_data=None):
         """
@@ -936,11 +967,14 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
 
         # Create Score
         response = self.client.get(self.results_endpoint)
+        response_with_trailing_slash = self.client.get(self.results_endpoint + '/')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_with_trailing_slash.status_code, 200)
 
         # There should be 2 results (not include the empty score user's result)
         self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response_with_trailing_slash.data), 2)
 
         # Check the data
         primary_user_results_endpoint = reverse(
@@ -983,7 +1017,7 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
 
     def test_retrieve_results_for_user_id(self):
         """
-        Test the LTI AGS LineItem Resul Retrieval for a single user.
+        Test the LTI AGS LineItem Result Retrieval for a single user.
         """
         self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly')
 
@@ -996,14 +1030,23 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
             }
         )
 
+        results_user_endpoint_with_trailing_slash = results_user_endpoint + '/'
+
         # Request results with userId
         response = self.client.get(results_user_endpoint, data={"userId": self.secondary_user_id})
+        response_with_trailing_slash = self.client.get(
+            results_user_endpoint_with_trailing_slash,
+            data={"userId": self.secondary_user_id},
+        )
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_with_trailing_slash.status_code, 200)
 
         # There should be 1 result for that user
         self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response_with_trailing_slash.data), 1)
         self.assertEqual(response.data[0]['userId'], self.secondary_user_id)
+        self.assertEqual(response_with_trailing_slash.data[0]['userId'], self.secondary_user_id)
 
     def test_retrieve_results_with_limit(self):
         """
@@ -1023,3 +1066,30 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
         # `primary_user_id` was assigned to the record with the `late_timestamp`
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['userId'], self.primary_user_id)
+
+    def test_results_serializer_id_includes_user_id_separator(self):
+        """
+        Test that the results serializer builds a valid URL for a user-specific result.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly')
+
+        results_user_endpoint = reverse(
+            'lti_consumer:lti-ags-view-results',
+            kwargs={
+                "lti_config_id": self.lti_config.id,
+                "pk": self.line_item.id,
+                "user_id": self.secondary_user_id,
+            }
+        )
+
+        response = self.client.get(results_user_endpoint, data={"userId": self.secondary_user_id})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(
+            response.data[0]['id'],
+            (
+                f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags'
+                f'/{self.line_item.id}/results/{self.secondary_user_id}'
+            ),
+        )

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -499,6 +499,29 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         call_args = self.xblock.set_user_module_score.call_args.args
         self.assertEqual(call_args, ('user_mock', 0.83, 1, 'This is exceptional work.'))
 
+    def test_xblock_grade_publish_with_zero_score(self):
+        """
+        Test that a `scoreGiven` of 0 is published to the LMS end-to-end, rather than being
+        silently skipped by the falsy-zero check this fix corrects.
+        """
+        # Set up LMS mocks
+        self._compat_mock.load_block_as_user.return_value = self.xblock
+        self._compat_mock.get_user_from_external_user_id.return_value = 'user_mock'
+        self.xblock.set_user_module_score = Mock()
+
+        # Set xblock attribute and make score request
+        self.xblock.has_score = True
+        self._post_lti_score({
+            "scoreGiven": 0,
+            "gradingProgress": "FullyGraded",
+        })
+
+        # Check if publish grade was called
+        self.xblock.set_user_module_score.assert_called_once()
+
+        call_args = self.xblock.set_user_module_score.call_args.args
+        self.assertEqual(call_args, ('user_mock', 0, 1, 'This is exceptional work.'))
+
     def test_grade_publish_score_bigger_than_maximum(self):
         """
         Test when given score is bigger than maximum score.
@@ -822,6 +845,36 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(LtiAgsScore.objects.all().count(), 0)
         self.assertEqual(response.status_code, 400)
         assert 'scoreMaximum' in response.data.keys()
+
+    def test_create_score_with_zero_score_maximum(self):
+        """
+        Test invalid request with `scoreMaximum: 0` -- present, but not a usable denominator.
+
+        Distinct from `test_create_score_with_missing_score_maximum`: `scoreMaximum` here is not
+        absent, so `validate_scoreMaximum` must reject it via an explicit `value <= 0` check
+        rather than the `value is None` check alone, and report the more accurate "must be a
+        positive number" message rather than "is a required field".
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/score')
+
+        response = self.client.post(
+            self.scores_endpoint,
+            data=json.dumps({
+                "timestamp": self.late_timestamp,
+                "scoreGiven": 0,
+                "scoreMaximum": 0,
+                "comment": "This is exceptional work.",
+                "activityProgress": LtiAgsScore.INITIALIZED,
+                "gradingProgress": LtiAgsScore.NOT_READY,
+                "userId": self.primary_user_id
+            }),
+            content_type="application/vnd.ims.lis.v1.score+json",
+        )
+
+        self.assertEqual(LtiAgsScore.objects.all().count(), 0)
+        self.assertEqual(response.status_code, 400)
+        assert 'scoreMaximum' in response.data.keys()
+        assert 'positive number' in str(response.data['scoreMaximum'])
 
     def test_erase_score(self):
         """

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -7,6 +7,12 @@ from rest_framework.test import APITransactionTestCase
 from rest_framework.reverse import reverse
 
 from lti_consumer.exceptions import LtiError
+from lti_consumer.lti_1p3.constants import (
+    LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR,
+    LTI_1P3_CONTEXT_ROLE_INSTRUCTOR,
+    LTI_1P3_CONTEXT_ROLE_LEARNER,
+    LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT,
+)
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration
 from lti_consumer.tests.test_utils import make_xblock
@@ -281,6 +287,71 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertIn('status', member_fields)
         self.assertIn('email', member_fields)
         self.assertIn('name', member_fields)
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', return_value=False)
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 1,
+            'instructor': 1,
+            'staff': 1,
+        })),
+    )
+    def test_get_membership_roles_mapping(self, expose_pii_fields_patcher):
+        """
+        Test context membership endpoint returns mapped LTI context role URIs.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint)
+
+        expose_pii_fields_patcher.assert_called()
+        self.assertEqual(len(response.data['members']), 3)
+
+        actual_roles = [set(member['roles']) for member in response.data['members']]
+
+        self.assertIn(
+            set(LTI_1P3_CONTEXT_ROLE_LEARNER),
+            actual_roles,
+        )
+        self.assertIn(
+            set(LTI_1P3_CONTEXT_ROLE_INSTRUCTOR),
+            actual_roles,
+        )
+        self.assertIn(
+            set(LTI_1P3_CONTEXT_ROLE_ADMINISTRATOR),
+            actual_roles,
+        )
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', return_value=False)
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 1,
+        })),
+    )
+    @patch('lti_consumer.plugin.compat.get_forum_role_model')
+    def test_get_membership_roles_mapping_includes_forum_roles(
+        self,
+        get_forum_role_model_patcher,
+        expose_pii_fields_patcher,
+    ):
+        """
+        Test context membership endpoint includes mapped forum roles.
+        """
+        fake_role = Mock()
+        fake_role.objects.filter.return_value.values_list.return_value = [(1000, 'Community TA')]
+        get_forum_role_model_patcher.return_value = fake_role
+
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint)
+
+        expose_pii_fields_patcher.assert_called()
+        fake_role.objects.filter.assert_called_once()
+        self.assertEqual(len(response.data['members']), 1)
+        self.assertEqual(
+            set(response.data['members'][0]['roles']),
+            set(LTI_1P3_CONTEXT_ROLE_LEARNER + LTI_1P3_CONTEXT_ROLE_TEACHING_ASSISTANT),
+        )
 
     @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
     @patch(

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -15,6 +15,7 @@ from lti_consumer.lti_1p3.constants import (
 )
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration
+from lti_consumer.plugin.views import LtiNrpsContextMembershipViewSet
 from lti_consumer.tests.test_utils import make_xblock
 
 
@@ -369,3 +370,179 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         response = self.client.get(self.context_membership_endpoint)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data['error'], 'above_response_limit')
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_returns_bounded_page(self):
+        """
+        Test that when limit is provided, the response contains at most 'limit' members
+        and includes a Link header with rel="next" when more members remain.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))
+        self.assertIn('rel="next"', response['Link'])
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_next_url_has_limit_and_page(self):
+        """
+        Test that the Link header's next URL contains the same limit and page=2
+        and preserves unrelated query params.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(
+            self.context_membership_endpoint,
+            {'limit': 2, 'role': 'foo'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.has_header('Link'))
+
+        link_header = response['Link']
+        parsed_links = self._parse_link_headers(link_header)
+        self.assertIn('next', parsed_links)
+
+        next_url = parsed_links['next']
+        self.assertIn('limit=2', next_url)
+        self.assertIn('page=2', next_url)
+        self.assertIn('role=foo', next_url)
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_last_page_omits_next(self):
+        """
+        Test that on the last page, no Link header with rel="next" is present.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_single_remaining(self):
+        """
+        Test that when limit=3 and page=2, only 1 member is returned and no next Link.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 3, 'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 1)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_invalid_limit_returns_all_members(self):
+        """
+        Test that an invalid limit (non-positive or non-integer) returns all members
+        without pagination.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        # Test with limit=0
+        response = self.client.get(self.context_membership_endpoint, {'limit': 0})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+        # Test with negative limit
+        response = self.client.get(self.context_membership_endpoint, {'limit': -5})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+        # Test with non-integer limit
+        response = self.client.get(self.context_membership_endpoint, {'limit': 'abc'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_invalid_page_defaults_to_one(self):
+        """
+        Test that an invalid page value defaults to page 1.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        # Test with page=0
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 0})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))
+
+        # Test with non-integer page
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 'abc'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    def test_pagination_sorts_by_id_for_stable_pages(self):
+        """Test pagination stays stable when member insertion order changes between requests.
+
+        The two page requests return the same members in opposite dictionary orders;
+        sorting by ID should still produce every member exactly once, without gaps or
+        duplicates.
+        """
+        members = [{'id': 2000 + i, 'username': f'user_{2000 + i}', 'roles': ['student']} for i in range(4)]
+        insertion_orders = [members, list(reversed(members))]
+
+        def get_members(_course_key):
+            return {member['id']: member for member in insertion_orders.pop(0)}
+
+        def attach_external_ids(data):
+            for member in data.values():
+                member['external_id'] = str(member['id'])
+
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        with patch('lti_consumer.plugin.views.compat.get_course_members', side_effect=get_members), patch.object(
+            LtiNrpsContextMembershipViewSet,
+            'attach_external_user_ids',
+            side_effect=attach_external_ids,
+        ):
+            page_ids = []
+            for page in (1, 2):
+                response = self.client.get(
+                    self.context_membership_endpoint,
+                    {'limit': 2, 'page': page},
+                )
+                self.assertEqual(response.status_code, 200)
+                page_ids.extend(member['user_id'] for member in response.data['members'])
+
+        self.assertEqual(page_ids, ['2000', '2001', '2002', '2003'])
+        self.assertEqual(len(page_ids), len(set(page_ids)))

--- a/lti_consumer/tests/unit/test_api.py
+++ b/lti_consumer/tests/unit/test_api.py
@@ -548,7 +548,7 @@ class TestGetLti1p3LaunchInfo(TestCase):
         an external configuration.
         """
         external_id = 'test-app:test-slug'
-        external_config = {'lti_1p3_client_id': 'test-client-id'}
+        external_config = {'lti_1p3_client_id': 'test-client-id', 'lti_1p3_deployment_id': '12'}
         filter_mock.return_value = external_config
         lti_config = LtiConfiguration.objects.create(
             version=LtiConfiguration.LTI_1P3,

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -75,6 +75,91 @@ class TestLtiConsumerXBlock(TestCase):
         self.compat.get_user_course_forum_role.return_value = None
 
 
+class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
+    """
+    Tests for LtiConsumerXBlock.get_resolved_lti_version().
+    """
+
+    def test_returns_external_version_key_when_external(self):
+        """
+        When config_type is external and external config has a "version"
+        key, that version takes priority over self.lti_version.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
+            mock_filter.return_value = {"version": "lti_1p3"}
+            self.assertEqual(self.xblock.get_resolved_lti_version(), "lti_1p3")
+            mock_filter.assert_called_once()
+
+    def test_falls_back_to_lti_version_when_no_external_version(self):
+        """
+        When external config has no "version" key, fall back to
+        self.lti_version.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
+            mock_filter.return_value = {"lti_1p3_client_id": "test"}
+            self.assertEqual(self.xblock.get_resolved_lti_version(), "lti_1p1")
+
+    def test_falls_back_on_filter_exception(self):
+        """
+        When get_external_config_from_filter raises, fall back to
+        self.lti_version instead of propagating the exception.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
+            mock_filter.side_effect = Exception("Filter service unavailable")
+            version = self.xblock.get_resolved_lti_version()
+            self.assertEqual(version, "lti_1p1")
+
+
+class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
+    """
+    Tests for LtiConsumerXBlock.resolve_external_config_version().
+    """
+
+    def _call_handler(self, config_id):
+        """Helper: build a JSON POST request, call handler, parse JSON body."""
+        body = json.dumps({'config_id': config_id}) if config_id is not None else '{}'
+        request = make_request(body, 'POST')
+        response = self.xblock.resolve_external_config_version(request)
+        return json.loads(response.body)  # pylint: disable=no-member
+
+    def test_returns_version_for_known_config(self):
+        """Returns version when config ID exists and has a version key."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.return_value = {'version': 'lti_1p3'}
+            result = self._call_handler('test-plugin:test-id')
+            self.assertEqual(result, {'found': True, 'version': 'lti_1p3'})
+
+    def test_returns_no_version_for_empty_config_id(self):
+        """Returns found=False when config_id is empty; does not call filter."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            result = self._call_handler('')
+            self.assertEqual(result, {'found': False, 'version': None})
+            mock_filter.assert_not_called()
+
+    def test_graceful_on_filter_exception(self):
+        """
+        When get_external_config_from_filter raises, handler returns
+        {'found': False, 'version': None} instead of 500.
+        """
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.side_effect = Exception("Filter service unavailable")
+            result = self._call_handler('test-plugin:test-id')
+            self.assertEqual(result, {'found': False, 'version': None})
+            mock_filter.assert_called_once()
+
+
 class TestIndexibility(TestCase):
     """
     Test indexibility of Lti Consumer XBlock
@@ -266,8 +351,11 @@ class TestProperties(TestLtiConsumerXBlock):
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     def test_validate_lti_id(self, mock_course):
         """
-        Test `lti_id` returns a warning if it's not set as an LTI passport in the course
+        Test `lti_id` returns a warning if it's not set as an LTI passport in the course.
+        Only applies when config_type is "new" and lti_version is "lti_1p1".
         """
+        self.xblock.config_type = "new"
+        self.xblock.lti_version = "lti_1p1"
         valid_provider = 'lti_provider'
         self.xblock.lti_id = valid_provider
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{valid_provider}:key:secret"])
@@ -277,6 +365,22 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.lti_id = "nonexistent"
         validation = self.xblock.validate()
         self.assertFalse(validation.empty)
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    @ddt.data('external', 'database')
+    def test_validate_lti_id_non_new_config(self, config_type, mock_course):
+        """
+        Non-'new' config types (external, database) should not trigger
+        LTI passport warning even when lti_version=lti_1p1 and lti_id
+        is invalid.
+        """
+        self.xblock.config_type = config_type
+        self.xblock.lti_version = "lti_1p1"
+        self.xblock.external_config = "test:x" if config_type == "external" else None
+        self.xblock.lti_id = "nonexistent"
+        type(mock_course).lti_passports = PropertyMock(return_value=["valid:key:secret"])
+        validation = self.xblock.validate()
+        self.assertTrue(validation.empty, f"{config_type} config should not produce LTI passport warning")
 
     def test_role(self):
         """
@@ -2402,27 +2506,6 @@ class TestLti1p3AccessTokenJWK(TestCase):
         response = self.xblock.lti_1p3_access_token(self.request)
         self.assertEqual(response.status_code, 400)
         self.assertJSONEqual(response.content, {'error': 'invalid_client'})
-
-
-class TestSubmitStudioEditsHandler(TestLtiConsumerXBlock):
-    """
-    Unit tests for LtiConsumerXBlock.submit_studio_edits()
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.xblock.lti_version = "lti_1p3"
-
-        db_config_waffle_patcher = patch('lti_consumer.lti_xblock.database_config_enabled', return_value=True)
-        db_config_waffle_patcher.start()
-        self.addCleanup(db_config_waffle_patcher.stop)
-
-        external_config_flag_patcher = patch(
-            'lti_consumer.lti_xblock.external_config_filter_enabled',
-            return_value=False
-        )
-        external_config_flag_patcher.start()
-        self.addCleanup(external_config_flag_patcher.stop)
 
 
 @ddt.ddt

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -72,6 +72,7 @@ class TestLtiConsumerXBlock(TestCase):
         self.compat.get_course_by_id.return_value = course
         self.compat.get_user_role.return_value = "student"
         self.compat.get_external_id_for_user.return_value = "12345"
+        self.compat.get_user_course_forum_role.return_value = None
 
 
 class TestIndexibility(TestCase):
@@ -316,6 +317,43 @@ class TestProperties(TestLtiConsumerXBlock):
         }
         with self.assertRaises(LtiError):
             _ = self.xblock.role
+
+    @ddt.data(
+        ('student', False, None, 'student'),
+        ('guest', False, 'Community TA', 'Community TA'),
+        ('student', False, 'Group Moderator', 'Group Moderator'),
+        ('student', True, 'Group Moderator', 'global_staff'),
+        ('staff', False, 'Community TA', 'staff'),
+        ('limited_staff', False, 'Group Moderator', 'limited_staff'),
+        ('instructor', False, 'Community TA', 'instructor'),
+    )
+    @ddt.unpack
+    def test_get_lti_1p3_user_role(self, base_role, user_is_staff, forum_role, expected_role):
+        """
+        Test effective LTI 1.3 role includes global staff and supported forum roles.
+        """
+        fake_user = Mock()
+        fake_user.opt_attrs = {
+            'edx-platform.user_id': FAKE_USER_ID,
+            'edx-platform.user_role': base_role,
+            'edx-platform.user_is_staff': user_is_staff,
+            'edx-platform.is_authenticated': True,
+        }
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.compat.get_user_course_forum_role.return_value = forum_role
+
+        # pylint: disable=protected-access
+        self.assertEqual(self.xblock._get_lti_1p3_user_role(), expected_role)
+
+        if base_role in {'staff', 'instructor', 'limited_staff'} or user_is_staff:
+            self.compat.get_user_course_forum_role.assert_not_called()
+        else:
+            self.compat.get_user_course_forum_role.assert_called_once_with(
+                FAKE_USER_ID,
+                self.xblock.scope_ids.usage_id.context_key,
+            )
+
+        self.compat.get_user_course_forum_role.reset_mock()
 
     def test_user_is_staff(self):
         """
@@ -757,7 +795,7 @@ class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{provider}:{key}:{secret}"])
 
         with patch('lti_consumer.plugin.compat.load_enough_xblock', return_value=self.xblock):
-            self.xblock.get_lti_consumer()  # pylint: disable=protected-access
+            self.xblock.get_lti_consumer()
 
         mock_lti_consumer.assert_called_with(self.xblock.launch_url, key, secret)
 
@@ -989,7 +1027,7 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
                 'roles': 'Student',
             })
         )
-        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)
         self.xblock.due = timezone.now()
         self.xblock.graceperiod = timedelta(days=1)
 
@@ -1156,7 +1194,7 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
         self.lti_provider_secret = 'secret'
         self.xblock.accept_grades_past_due = True
         self.mock_lti_consumer = Mock()
-        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)
 
         mock_user = Mock()
         mock_id = PropertyMock(return_value=1)
@@ -1642,7 +1680,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).lti_launch_url = PropertyMock(return_value=lti_launch_url)
-        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)
 
         context = self.xblock._get_context_for_template()  # pylint: disable=protected-access
         self.assertEqual(context['launch_url'], lti_launch_url)
@@ -1662,7 +1700,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_1p3_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).launch_url = PropertyMock(return_value=lti_1p3_launch_url)
-        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)
 
         # Calling _get_lti_block_launch_handler raises an error because the mocked XBlock location attribute does not
         # act like a UsageKey, so mock out get_lti_1p3_launch_data to avoid accessing it.
@@ -1927,6 +1965,34 @@ class TestLtiConsumer1p3XBlock(TestCase):
             expected_launch_data
         )
         self.xblock.get_lti_1p3_custom_parameters.assert_called_once_with()
+
+    @patch('lti_consumer.lti_xblock.compat.get_user_course_forum_role')
+    def test_get_lti_1p3_launch_data_uses_forum_role(self, mock_get_user_course_forum_role):
+        """
+        Test that get_lti_1p3_launch_data uses forum role for supported non-staff users.
+        """
+        fake_user = Mock()
+        fake_user.opt_attrs = {
+            'edx-platform.user_id': 1,
+            'edx-platform.user_role': 'student',
+            'edx-platform.is_authenticated': True,
+            'edx-platform.username': 'fake_username',
+        }
+
+        self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
+        self.xblock.runtime.service(self, 'user').get_external_user_id = Mock(return_value="external_user_id")
+        self.xblock.get_context_title = Mock(return_value="context_title")
+        self.xblock.get_pii_sharing_enabled = Mock(return_value=False)
+        self.xblock.get_lti_1p3_custom_parameters = Mock(return_value={})
+        mock_get_user_course_forum_role.return_value = 'Community TA'
+
+        launch_data = self.xblock.get_lti_1p3_launch_data()
+
+        self.assertEqual(launch_data.user_role, 'Community TA')
+        mock_get_user_course_forum_role.assert_called_once_with(
+            1,
+            self.xblock.scope_ids.usage_id.context_key,
+        )
 
     @patch('lti_consumer.plugin.compat.get_course_by_id')
     def test_get_context_title(self, mock_get_course_by_id):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1482,6 +1482,25 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
         mock_lti_consumer.get_result.assert_called_with(0.5, 'test')
 
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.module_score', PropertyMock(return_value=0))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.score_comment', PropertyMock(return_value='test'))
+    def test_consumer_get_result_called_with_zero_score(self):
+        """
+        Test LtiConsumer.get_result is called with a `module_score` of 0, rather than that score
+        being silently omitted.
+
+        `module_score` is falsy for a real, graded score of 0.0; `_result_service_get` previously
+        checked it for truthiness, so a learner scored 0 was reported as ungraded (no
+        `resultScore` in the response) instead of graded 0 -- the same falsy-zero pattern fixed
+        for LTI 1.3 AGS elsewhere in this change.
+        """
+        mock_lti_consumer = Mock()
+        mock_user = Mock()
+
+        self.xblock._result_service_get(mock_lti_consumer, mock_user)  # pylint: disable=protected-access
+
+        mock_lti_consumer.get_result.assert_called_with(0, 'test')
+
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.clear_user_module_score', Mock(return_value=True))
     @patch('lti_consumer.lti_xblock.parse_result_json')
     def test_consumer_put_result_called(self, mock_parse_result_json):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -742,7 +742,7 @@ class TestEditableFields(TestLtiConsumerXBlock):
 
 class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
     """
-    Unit tests for LtiConsumerXBlock._get_lti_consumer()
+    Unit tests for LtiConsumerXBlock.get_lti_consumer()
     """
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     @patch('lti_consumer.models.LtiConsumer1p1')
@@ -757,7 +757,7 @@ class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{provider}:{key}:{secret}"])
 
         with patch('lti_consumer.plugin.compat.load_enough_xblock', return_value=self.xblock):
-            self.xblock._get_lti_consumer()  # pylint: disable=protected-access
+            self.xblock.get_lti_consumer()  # pylint: disable=protected-access
 
         mock_lti_consumer.assert_called_with(self.xblock.launch_url, key, secret)
 
@@ -989,7 +989,7 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
                 'roles': 'Student',
             })
         )
-        self.xblock._get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
         self.xblock.due = timezone.now()
         self.xblock.graceperiod = timedelta(days=1)
 
@@ -1156,7 +1156,7 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
         self.lti_provider_secret = 'secret'
         self.xblock.accept_grades_past_due = True
         self.mock_lti_consumer = Mock()
-        self.xblock._get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
 
         mock_user = Mock()
         mock_id = PropertyMock(return_value=1)
@@ -1165,12 +1165,13 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
     @override_settings(DEBUG=True)
     @patch('lti_consumer.lti_xblock.log_authorization_header')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret')
-    def test_runtime_debug_true(self, mock_lti_provider_key_secret, mock_log_auth_header):
+    def test_runtime_debug_true(self, mock_log_auth_header):
         """
         Test `log_authorization_header` is called when settings.DEBUG is True
         """
-        mock_lti_provider_key_secret.__get__ = Mock(return_value=(self.lti_provider_key, self.lti_provider_secret))
+        self.mock_lti_consumer.oauth_key = self.lti_provider_key
+        self.mock_lti_consumer.oauth_secret = self.lti_provider_secret
+
         request = make_request('', 'GET')
         self.xblock.result_service_handler(request)
 
@@ -1641,7 +1642,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).lti_launch_url = PropertyMock(return_value=lti_launch_url)
-        self.xblock._get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
 
         context = self.xblock._get_context_for_template()  # pylint: disable=protected-access
         self.assertEqual(context['launch_url'], lti_launch_url)
@@ -1661,7 +1662,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_1p3_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).launch_url = PropertyMock(return_value=lti_1p3_launch_url)
-        self.xblock._get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
 
         # Calling _get_lti_block_launch_handler raises an error because the mocked XBlock location attribute does not
         # act like a UsageKey, so mock out get_lti_1p3_launch_data to avoid accessing it.

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -690,6 +690,15 @@ class TestLtiAgsScoreModel(TestCase):
             self.score.score_maximum = None
             self.score.save()
 
+    def test_no_score_max_fails_when_setting_zero_score(self):
+        """
+        Test that a `scoreGiven` of zero is still treated as a score that requires `scoreMaximum`.
+        """
+        with self.assertRaises(ValidationError):
+            self.score.score_given = 0
+            self.score.score_maximum = None
+            self.score.save()
+
     def test_repr(self):
         """
         Test String representation of model.

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -133,6 +133,58 @@ class TestLtiConfigurationModel(TestCase):
         self.assertEqual(self.lti_1p1_external.get_lti_consumer(), "consumer")
         mock_consumer.assert_called_once_with("https://example.com", "client_key", "secret")
 
+    @patch("lti_consumer.models.LtiConfiguration._get_lti_1p3_consumer")
+    @patch("lti_consumer.models.LtiConfiguration._get_lti_1p1_consumer")
+    @patch("lti_consumer.models.get_external_config_from_filter")
+    def test_get_lti_consumer_external_config_version_takes_priority(
+        self, mock_filter, mock_1p1, mock_1p3
+    ):
+        """
+        When config_store is external, the version from external config
+        should take priority over the stored version field.
+        """
+        # External config returns LTI 1.3, even though local version is LTI 1.1
+        mock_filter.return_value = {
+            "version": LtiConfiguration.LTI_1P3,
+            "lti_1p3_client_id": "test-client",
+        }
+        mock_1p3.return_value = "lti_1p3_consumer"
+        mock_1p1.return_value = "lti_1p1_consumer"
+
+        result = self.lti_1p1_external.get_lti_consumer()
+
+        self.assertEqual(result, "lti_1p3_consumer")
+        mock_1p3.assert_called_once()
+        mock_1p1.assert_not_called()
+
+    @patch("lti_consumer.models.get_external_config_from_filter")
+    def test_get_effective_version_falls_back_on_external_without_version(
+        self, mock_filter
+    ):
+        """
+        External config without a "version" key falls back to the
+        stored version field.
+        """
+        mock_filter.return_value = {"lti_1p3_client_id": "test"}
+        config = LtiConfiguration.objects.create(
+            version=LtiConfiguration.LTI_1P1,
+            config_store=LtiConfiguration.CONFIG_EXTERNAL,
+            external_id="test:x",
+            location='block-v1:course+test+2020+type@problem+block@effver-fallback',
+        )
+        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P1)
+
+    def test_get_effective_version_non_external(self):
+        """
+        Non-external config_store returns the stored version directly.
+        """
+        config = LtiConfiguration.objects.create(
+            version=LtiConfiguration.LTI_1P3,
+            config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
+            location='block-v1:course+test+2020+type@problem+block@effver-non-ext',
+        )
+        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P3)
+
     def test_repr(self):
         """
         Test String representation of model.

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -692,11 +692,30 @@ class TestLtiAgsScoreModel(TestCase):
 
     def test_no_score_max_fails_when_setting_zero_score(self):
         """
-        Test that a `scoreGiven` of zero is still treated as a score that requires `scoreMaximum`.
+        Test that the model raises the same exception for a `scoreGiven` of 0 without
+        `scoreMaximum`, not just for a truthy `scoreGiven`.
+
+        `clean()` previously checked `self.score_given` for truthiness, which let a
+        `scoreGiven` of 0 (falsy but valid) through without `scoreMaximum` set.
         """
         with self.assertRaises(ValidationError):
             self.score.score_given = 0
             self.score.score_maximum = None
+            self.score.save()
+
+    def test_score_max_fails_when_zero_with_score_given_set(self):
+        """
+        Test that the model rejects `scoreMaximum=0` alongside a set `scoreGiven`, not just
+        `scoreMaximum=None`.
+
+        A `scoreMaximum` of 0 isn't a usable denominator either, and previously `clean()` only
+        checked for `None`, so this combination could be saved via the ORM/admin -- silently
+        skipped by `publish_grade_on_score_update`, yet still reported as a fabricated
+        "successful" result (`resultMaximum: 1`) by `LtiAgsResultSerializer.get_resultMaximum`.
+        """
+        with self.assertRaises(ValidationError):
+            self.score.score_given = 10
+            self.score.score_maximum = 0
             self.score.save()
 
     def test_repr(self):

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -348,7 +348,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.mock_get_user_id_patcher_enabled.return_value = mock_user
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_handle_replace_result_success(self):
         """
@@ -407,7 +407,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('Request body XML parsing error', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_invalid_signature(self, mock_verify):
         """
@@ -422,7 +422,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('failure', self.outcome_service.handle_request(request))
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_user_not_found(self):
         """
@@ -437,7 +437,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('User not found', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'unsupportedRequest')))
     def test_unsupported_action(self):
         """

--- a/lti_consumer/tests/unit/test_signals.py
+++ b/lti_consumer/tests/unit/test_signals.py
@@ -4,6 +4,7 @@ Tests for LTI Advantage Assignments and Grades Service views.
 from datetime import datetime
 from unittest.mock import patch, Mock
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from opaque_keys.edx.keys import UsageKey
 
@@ -101,10 +102,11 @@ class PublishGradeOnScoreUpdateTest(TestCase):
 
     def test_grade_publish_with_zero_score(self):
         """
-        Test that a `scoreGiven` of zero is published to the LMS gradebook.
+        Test that a `scoreGiven` of 0 is published like any other score.
 
-        A zero is a valid grade, so it must not be skipped the way a missing
-        `scoreGiven` is.
+        `score_given` is falsy for a `FloatField` value of `0.0`. Before this fix, the guard used
+        a truthiness check (`and instance.score_given`) and silently skipped a legitimate zero
+        score; it must now use `is not None` so 0 is treated as a present, valid grade.
         """
         line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
@@ -124,19 +126,18 @@ class PublishGradeOnScoreUpdateTest(TestCase):
             timestamp=datetime.now(),
         )
 
-        # Check that the grade is published, and that it is published as a zero.
-        self._compat_mock.load_block_as_user.assert_called_once()
-        self._compat_mock.get_user_from_external_user_id.assert_called_once()
-        self._block_mock.set_user_module_score.assert_called_once_with(
-            self._compat_mock.get_user_from_external_user_id.return_value,
-            0.0,
-            self._block_mock.max_score.return_value,
-            None,
-        )
+        self._block_mock.set_user_module_score.assert_called_once()
+        call_args = self._block_mock.set_user_module_score.call_args.args
+        self.assertEqual(call_args[1], 0)
 
-    def test_grade_publish_not_done_when_score_given_is_null(self):
+    def test_grade_publish_not_done_when_score_given_missing(self):
         """
-        Test that a score without a `scoreGiven` is not published to the LMS gradebook.
+        Test that grade publish is still skipped (not errored) when `score_given` is absent, e.g.
+        an AGS "erase score" request that nulls out `scoreGiven`/`scoreMaximum`.
+
+        Unlike the zero-score case above, this is unchanged behavior: `score_given=None` was
+        already falsy under the old truthiness check, and is also caught by the new
+        `is not None` check, so this is a lock-in test rather than a new assertion.
         """
         line_item = LtiAgsLineItem.objects.create(
             lti_configuration=self.lti_config,
@@ -156,7 +157,45 @@ class PublishGradeOnScoreUpdateTest(TestCase):
             timestamp=datetime.now(),
         )
 
-        # Check that methods to save grades are not called
         self._block_mock.set_user_module_score.assert_not_called()
-        self._compat_mock.get_user_from_external_user_id.assert_not_called()
+        self._compat_mock.load_block_as_user.assert_not_called()
+
+    def test_grade_publish_not_done_when_score_maximum_zero(self):
+        """
+        Test that `score_maximum=0` alongside a set `score_given` is rejected at save time,
+        never reaching the publish signal at all.
+
+        This combination can't be produced through the AGS API (the serializer rejects a
+        `scoreMaximum` of 0). It previously could still be produced via the Django admin or
+        direct ORM access -- `MinValueValidator(0)` and the old `LtiAgsScore.clean()` both
+        permitted it (0 is a valid, non-`None` value) -- reaching this signal, whose normalized-
+        score division would otherwise crash on it (worked around, at the time, by a
+        `score_maximum > 0` guard in the signal itself).
+
+        `LtiAgsScore.clean()` now rejects `score_maximum <= 0` whenever `score_given` is set
+        (not just `score_maximum is None`), closing the gap at the source: this state can no
+        longer be saved at all, so the signal's own guard is never exercised by it. See
+        `lti_consumer.tests.unit.test_models.TestLtiAgsScoreModel.
+        test_score_max_fails_when_zero_with_score_given_set` for the model-level assertion.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        with self.assertRaises(ValidationError):
+            LtiAgsScore.objects.create(
+                line_item=line_item,
+                score_given=10,
+                score_maximum=0,
+                activity_progress=LtiAgsScore.COMPLETED,
+                grading_progress=LtiAgsScore.FULLY_GRADED,
+                user_id="test",
+                timestamp=datetime.now(),
+            )
+
+        self._block_mock.set_user_module_score.assert_not_called()
         self._compat_mock.load_block_as_user.assert_not_called()

--- a/lti_consumer/tests/unit/test_signals.py
+++ b/lti_consumer/tests/unit/test_signals.py
@@ -98,3 +98,65 @@ class PublishGradeOnScoreUpdateTest(TestCase):
         self._block_mock.set_user_module_score.assert_called_once()
         self._compat_mock.get_user_from_external_user_id.assert_called_once()
         self._compat_mock.load_block_as_user.assert_called_once()
+
+    def test_grade_publish_with_zero_score(self):
+        """
+        Test that a `scoreGiven` of zero is published to the LMS gradebook.
+
+        A zero is a valid grade, so it must not be skipped the way a missing
+        `scoreGiven` is.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        LtiAgsScore.objects.create(
+            line_item=line_item,
+            score_given=0,
+            score_maximum=100,
+            activity_progress=LtiAgsScore.COMPLETED,
+            grading_progress=LtiAgsScore.FULLY_GRADED,
+            user_id="test",
+            timestamp=datetime.now(),
+        )
+
+        # Check that the grade is published, and that it is published as a zero.
+        self._compat_mock.load_block_as_user.assert_called_once()
+        self._compat_mock.get_user_from_external_user_id.assert_called_once()
+        self._block_mock.set_user_module_score.assert_called_once_with(
+            self._compat_mock.get_user_from_external_user_id.return_value,
+            0.0,
+            self._block_mock.max_score.return_value,
+            None,
+        )
+
+    def test_grade_publish_not_done_when_score_given_is_null(self):
+        """
+        Test that a score without a `scoreGiven` is not published to the LMS gradebook.
+        """
+        line_item = LtiAgsLineItem.objects.create(
+            lti_configuration=self.lti_config,
+            resource_id="test",
+            resource_link_id=self.location,
+            label="test label",
+            score_maximum=100
+        )
+
+        LtiAgsScore.objects.create(
+            line_item=line_item,
+            score_given=None,
+            score_maximum=None,
+            activity_progress=LtiAgsScore.COMPLETED,
+            grading_progress=LtiAgsScore.FULLY_GRADED,
+            user_id="test",
+            timestamp=datetime.now(),
+        )
+
+        # Check that methods to save grades are not called
+        self._block_mock.set_user_module_score.assert_not_called()
+        self._compat_mock.get_user_from_external_user_id.assert_not_called()
+        self._compat_mock.load_block_as_user.assert_not_called()


### PR DESCRIPTION
## Description

Backport of the LTI 1.3 / LTI Advantage fixes onto the Ulmo baseline.

The base branch `ulmo/lti_fixes_backport` is at `02ad974`, which is tag **v9.14.3** — the version Ulmo pins (`lti-consumer-xblock==9.14.3` in `release/ulmo.4`). That commit is the direct ancestor of this branch, so the diff here is only the backported work rather than the 9.x-against-11.x noise a comparison with `master` produces.

Each change was re-implemented against this release line where the upstream version did not apply cleanly; it is not a straight cherry-pick series. Notable adaptations are called out in the CHANGELOG entries.

## What is included

Fixes already merged upstream on `master`:

| Issue | Upstream PR | Change |
|---|---|---|
| #605 | #609 | Allow programmatic AGS line-item creation using `resource_link_id` when `resource_id` is absent |
| #610, #611 | #612 | Add course context claims to deep-linking launches; use the deployment ID from the reusable LTI config |
| #618 | #645 | Map Open edX course and discussion roles to standard LTI context roles for launches and NRPS memberships |
| #620, #628, #633, #637 | #643 | LTI 1.1 key/secret pair selection for Basic Outcomes, AGS results trailing-slash handling, deep-linking `target_link_uri`, and blank AGS score comments |
| #657 | #663 | Derive the effective LTI version from reusable external configurations |
| #653 | #654 | POST deep-linking authentication responses to the tool-provided `redirect_uri` |
| #669 | #670 | NRPS pagination via `limit`/`page` with `rel="next"` Link headers |

Two adaptations worth flagging:

- **#609** — the `resource_link_id` URL-encoding half is intentionally omitted. It belongs to PR #607, which was reverted upstream in PR #623.
- **#663** — upstream also reworked the Studio editor into a multi-step wizard (#650). This line keeps its existing flat editor, so only the field show/hide behaviour was ported, not the live version preview.

## Not yet merged upstream

The last two commits backport the zero-value AGS score fix for issue #695, which is **still in review on `master` as #701**. If #701 changes during review, this branch should be updated to match before merging. The rest of the branch does not depend on it.

## Testing

Full suite green on this branch: **718 tests**, `pycodestyle` and `pylint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)